### PR TITLE
Add Prisma integration and FOR EACH interpreter support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "js4gl",
+  "version": "0.1.0",
+  "private": true,
+  "type": "commonjs",
+  "scripts": {
+    "seed": "node prisma/seed.js"
+  },
+  "dependencies": {
+    "@prisma/client": "^5.16.1"
+  },
+  "devDependencies": {
+    "prisma": "^5.16.1"
+  }
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,25 @@
+datasource db {
+  provider = "sqlite"
+  url      = "file:./dev.db"
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model Customer {
+  id        Int      @id @default(autoincrement())
+  name      String
+  email     String   @unique
+  createdAt DateTime @default(now())
+  orders    Order[]
+}
+
+model Order {
+  id         Int      @id @default(autoincrement())
+  total      Float
+  status     String
+  placedAt   DateTime @default(now())
+  customer   Customer @relation(fields: [customerId], references: [id])
+  customerId Int
+}

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -1,0 +1,56 @@
+const { PrismaClient } = require('@prisma/client');
+
+const prisma = new PrismaClient();
+
+async function main() {
+  await prisma.order.deleteMany();
+  await prisma.customer.deleteMany();
+
+  const customers = await Promise.all([
+    prisma.customer.create({
+      data: {
+        name: 'Alice Martin',
+        email: 'alice@example.com',
+        orders: {
+          create: [
+            { total: 125.5, status: 'PROCESSING' },
+            { total: 89.99, status: 'SHIPPED' }
+          ]
+        }
+      },
+      include: { orders: true }
+    }),
+    prisma.customer.create({
+      data: {
+        name: 'Bruno Keller',
+        email: 'bruno@example.com',
+        orders: {
+          create: [
+            { total: 45.0, status: 'PENDING' }
+          ]
+        }
+      },
+      include: { orders: true }
+    }),
+    prisma.customer.create({
+      data: {
+        name: 'Carla Dupont',
+        email: 'carla@example.com',
+        orders: {
+          create: []
+        }
+      }
+    })
+  ]);
+
+  console.log(`Seeded ${customers.length} customers and ${customers.reduce((sum, c) => sum + (c.orders?.length || 0), 0)} orders.`);
+}
+
+main()
+  .catch((e) => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/src/db.js
+++ b/src/db.js
@@ -1,0 +1,14 @@
+const { PrismaClient } = require('@prisma/client');
+
+let prismaInstance = null;
+
+function getPrismaClient() {
+  if (!prismaInstance) {
+    prismaInstance = new PrismaClient();
+  }
+  return prismaInstance;
+}
+
+module.exports = {
+  prisma: getPrismaClient()
+};

--- a/test.js
+++ b/test.js
@@ -9,8 +9,17 @@ const program = `
   DISPLAY "done".
 `;
 
-const { output } = interpret4GL(program, { inputs: [], onOutput: console.log });
-
-if (require.main === module) {
-  console.log(`\n${output.length} ligne(s) affichée(s).`);
+async function run() {
+  const { output } = await interpret4GL(program, { inputs: [], onOutput: console.log });
+  if (require.main === module) {
+    console.log(`\n${output.length} ligne(s) affichée(s).`);
+  }
+  return output;
 }
+
+run().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});
+
+module.exports = { run };


### PR DESCRIPTION
## Summary
- add Prisma configuration (package.json, schema, seed) and a reusable Prisma client helper
- update the interpreter to be async, inject a Prisma client, and parse FOR EACH statements with field access
- translate FOR EACH statements into Prisma findMany queries supporting WHERE/BY/OF and execute nested blocks
- adapt the CLI test harness to await asynchronous interpretation

## Testing
- node test.js

------
https://chatgpt.com/codex/tasks/task_e_68dd30db071483218acfbf31ed87e2db