### PR TITLE
Add MONTH/ENTRY builtins and date formatting helpers

### DIFF
--- a/test.js
+++ b/test.js
@@ -1,25 +1,67 @@
+const assert = require('assert');
 const { interpret4GL } = typeof Mini4GL !== 'undefined' ? Mini4GL : require('./mini4GL.js');
 
-const program = `
-  ASSIGN n = 3.
-  DO WHILE n > 0:
-    DISPLAY "tick", n.
-    n = n - 1.
-  END.
-  DISPLAY "done".
-`;
-
-async function run() {
-  const { output } = await interpret4GL(program, { inputs: [], onOutput: console.log });
-  if (require.main === module) {
-    console.log(`\n${output.length} ligne(s) affichée(s).`);
+const tests = [
+  {
+    name: 'MONTH converts ISO and slash-separated dates to month numbers',
+    program: `
+      DISPLAY MONTH("2024-03-15").
+      DISPLAY MONTH("2024/11/05").
+    `,
+    verify: ({ output }) => {
+      assert.deepStrictEqual(output, ['3', '11']);
+    }
+  },
+  {
+    name: 'ENTRY splits lists with default and custom delimiters',
+    program: `
+      DISPLAY ENTRY(2, "alpha,beta,gamma").
+      DISPLAY ENTRY(3, "a|b|c", "|").
+      DISPLAY ENTRY(5, "x,y,z").
+    `,
+    verify: ({ output }) => {
+      assert.deepStrictEqual(output, ['beta', 'c', '']);
+    }
+  },
+  {
+    name: 'FORMAT "99/99/99" reformats date strings before output',
+    program: `
+      DEFINE VARIABLE orderDate AS CHARACTER INIT "2024-05-17".
+      DISPLAY orderDate FORMAT "99/99/99".
+      DISPLAY orderDate FORMAT "99-99-9999".
+      DISPLAY orderDate.
+    `,
+    verify: ({ output }) => {
+      assert.deepStrictEqual(output, ['17/05/24', '17-05-2024', '2024-05-17']);
+    }
   }
-  return output;
+];
+
+async function runSingleTest(test){
+  const result = await interpret4GL(test.program, { inputs: [], onOutput: () => {} });
+  test.verify(result);
+  return result;
 }
 
-run().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+async function run(){
+  const outcomes=[];
+  for(const test of tests){
+    const result=await runSingleTest(test);
+    outcomes.push({ name: test.name, output: result.output });
+    console.log(`✓ ${test.name}`);
+  }
+  return outcomes;
+}
+
+if(require.main === module){
+  run()
+    .then(() => {
+      console.log(`\n${tests.length} test(s) réussi(s).`);
+    })
+    .catch(err => {
+      console.error(err);
+      process.exit(1);
+    });
+}
 
 module.exports = { run };


### PR DESCRIPTION
## Summary
- add 4GL date parsing and formatting helpers to support FORMAT masks
- implement MONTH and ENTRY built-in functions in expression evaluation
- cover the new functionality with targeted unit tests

## Testing
- node test.js

------
https://chatgpt.com/codex/tasks/task_e_68dd3c253f8483219e55a878e23abc9f