### PR TITLE
Add database seeding endpoint and UI trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,18 @@ Mini interpréteur JavaScript pour un sous-ensemble du langage OpenEdge/Progress
 
 ## Tester dans le navigateur
 
-Une page de démonstration est disponible dans [`index.html`](./index.html). Ouvrez-la dans un navigateur web moderne (ou servez le dossier via `npx serve` / `python -m http.server`) pour profiter de :
+Une page de démonstration est disponible dans [`index.html`](./index.html). Ouvrez-la dans un navigateur web moderne (ou servez le dossier via `npm start`, `npx serve` ou `python -m http.server`) pour profiter de :
 
 - Un éditeur intégré avec un exemple de programme 4GL.
 - Un bouton **Run** pour exécuter le code et afficher la sortie en direct.
 - Un bouton **Save** pour télécharger le contenu courant de l'éditeur sous forme de fichier `.4gl`.
+- Un bouton **Générer les données** pour réinitialiser la base SQLite de démonstration via l'API `/api/seed` (servie par `npm start`).
 - Une sauvegarde automatique locale (LocalStorage) du dernier programme édité.
 
+
+```bash
+npm start
+```
 
 ```bash
 npx serve

--- a/index.html
+++ b/index.html
@@ -117,6 +117,7 @@
         <div class="controls">
           <button id="run">Run</button>
           <button id="save" class="secondary">Save</button>
+          <button id="seed" class="secondary">Générer les données</button>
           <label>
             Nom du fichier
             <input type="text" id="filename" value="programme.4gl" />
@@ -141,6 +142,7 @@
       const editor = document.getElementById('editor');
       const runBtn = document.getElementById('run');
       const saveBtn = document.getElementById('save');
+      const seedBtn = document.getElementById('seed');
       const outputEl = document.getElementById('output');
       const statusEl = document.getElementById('status');
       const filenameInput = document.getElementById('filename');
@@ -206,6 +208,27 @@
         URL.revokeObjectURL(url);
         setStatus('Programme téléchargé.', false);
       });
+
+      if (seedBtn) {
+        seedBtn.addEventListener('click', async () => {
+          setStatus('Génération des données de démonstration...');
+          try {
+            const response = await fetch('/api/seed', { method: 'POST' });
+            if (!response.ok) {
+              throw new Error(`Requête échouée (${response.status})`);
+            }
+            const payload = await response.json();
+            if (payload.status !== 'ok') {
+              throw new Error(payload.message || 'Erreur lors de la génération des données.');
+            }
+            const details = `${payload.customers} client(s), ${payload.orders} commande(s)`;
+            setStatus(`Base de démonstration régénérée (${details}).`);
+          } catch (err) {
+            console.error(err);
+            setStatus(err.message || 'Impossible de générer les données.', true);
+          }
+        });
+      }
     </script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "commonjs",
   "scripts": {
-    "seed": "node prisma/seed.js"
+    "seed": "node prisma/seed.js",
+    "start": "node src/server.js"
   },
   "dependencies": {
     "@prisma/client": "^5.16.1"

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -1,52 +1,12 @@
 const { PrismaClient } = require('@prisma/client');
+const { seedDatabase } = require('../src/seedDatabase');
 
 const prisma = new PrismaClient();
 
-async function main() {
-  await prisma.order.deleteMany();
-  await prisma.customer.deleteMany();
-
-  const customers = await Promise.all([
-    prisma.customer.create({
-      data: {
-        name: 'Alice Martin',
-        email: 'alice@example.com',
-        orders: {
-          create: [
-            { total: 125.5, status: 'PROCESSING' },
-            { total: 89.99, status: 'SHIPPED' }
-          ]
-        }
-      },
-      include: { orders: true }
-    }),
-    prisma.customer.create({
-      data: {
-        name: 'Bruno Keller',
-        email: 'bruno@example.com',
-        orders: {
-          create: [
-            { total: 45.0, status: 'PENDING' }
-          ]
-        }
-      },
-      include: { orders: true }
-    }),
-    prisma.customer.create({
-      data: {
-        name: 'Carla Dupont',
-        email: 'carla@example.com',
-        orders: {
-          create: []
-        }
-      }
-    })
-  ]);
-
-  console.log(`Seeded ${customers.length} customers and ${customers.reduce((sum, c) => sum + (c.orders?.length || 0), 0)} orders.`);
-}
-
-main()
+seedDatabase(prisma)
+  .then(({ customersCreated, ordersCreated }) => {
+    console.log(`Seeded ${customersCreated} customers and ${ordersCreated} orders.`);
+  })
   .catch((e) => {
     console.error(e);
     process.exit(1);

--- a/src/seedDatabase.js
+++ b/src/seedDatabase.js
@@ -1,0 +1,64 @@
+const { PrismaClient } = require('@prisma/client');
+
+async function seedDatabase(existingClient) {
+  const prisma = existingClient ?? new PrismaClient();
+  const shouldDisconnect = !existingClient;
+
+  try {
+    await prisma.order.deleteMany();
+    await prisma.customer.deleteMany();
+
+    const customers = await Promise.all([
+      prisma.customer.create({
+        data: {
+          name: 'Alice Martin',
+          email: 'alice@example.com',
+          orders: {
+            create: [
+              { total: 125.5, status: 'PROCESSING' },
+              { total: 89.99, status: 'SHIPPED' }
+            ]
+          }
+        },
+        include: { orders: true }
+      }),
+      prisma.customer.create({
+        data: {
+          name: 'Bruno Keller',
+          email: 'bruno@example.com',
+          orders: {
+            create: [{ total: 45.0, status: 'PENDING' }]
+          }
+        },
+        include: { orders: true }
+      }),
+      prisma.customer.create({
+        data: {
+          name: 'Carla Dupont',
+          email: 'carla@example.com'
+        },
+        include: { orders: true }
+      })
+    ]);
+
+    const ordersCreated = customers.reduce(
+      (sum, customer) => sum + (customer.orders?.length || 0),
+      0
+    );
+
+    return {
+      customersCreated: customers.length,
+      ordersCreated,
+      customers
+    };
+  } finally {
+    if (shouldDisconnect) {
+      await prisma.$disconnect();
+    }
+  }
+}
+
+module.exports = {
+  seedDatabase
+};
+

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,79 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const { prisma } = require('./db');
+const { seedDatabase } = require('./seedDatabase');
+
+const PORT = process.env.PORT ? Number(process.env.PORT) : 3000;
+const ROOT_DIR = path.resolve(__dirname, '..');
+
+function sendJson(res, statusCode, payload) {
+  const body = JSON.stringify(payload);
+  res.writeHead(statusCode, {
+    'Content-Type': 'application/json; charset=utf-8',
+    'Content-Length': Buffer.byteLength(body)
+  });
+  res.end(body);
+}
+
+function sendFile(res, filePath) {
+  fs.readFile(filePath, (err, data) => {
+    if (err) {
+      res.statusCode = err.code === 'ENOENT' ? 404 : 500;
+      res.end(res.statusCode === 404 ? 'Not found' : 'Internal server error');
+      return;
+    }
+    const ext = path.extname(filePath).toLowerCase();
+    const contentType = {
+      '.html': 'text/html; charset=utf-8',
+      '.js': 'application/javascript; charset=utf-8',
+      '.css': 'text/css; charset=utf-8',
+      '.json': 'application/json; charset=utf-8'
+    }[ext] || 'application/octet-stream';
+
+    res.writeHead(200, { 'Content-Type': contentType });
+    res.end(data);
+  });
+}
+
+const server = http.createServer(async (req, res) => {
+  const { method } = req;
+  const url = new URL(req.url, `http://${req.headers.host}`);
+
+  if (method === 'POST' && url.pathname === '/api/seed') {
+    try {
+      const result = await seedDatabase(prisma);
+      sendJson(res, 200, {
+        status: 'ok',
+        customers: result.customersCreated,
+        orders: result.ordersCreated
+      });
+    } catch (error) {
+      console.error('Failed to seed database', error);
+      sendJson(res, 500, { status: 'error', message: 'Impossible de générer les données.' });
+    }
+    return;
+  }
+
+  if (method === 'GET' && url.pathname === '/api/seed') {
+    sendJson(res, 405, { status: 'error', message: 'Method Not Allowed' });
+    return;
+  }
+
+  if (method === 'GET') {
+    let filePath = path.join(ROOT_DIR, url.pathname);
+    if (url.pathname === '/' || url.pathname === '') {
+      filePath = path.join(ROOT_DIR, 'index.html');
+    }
+    sendFile(res, filePath);
+    return;
+  }
+
+  res.statusCode = 404;
+  res.end('Not found');
+});
+
+server.listen(PORT, () => {
+  console.log(`Mini4GL demo server ready on http://localhost:${PORT}`);
+});
+


### PR DESCRIPTION
## Summary
- factor database seeding into a reusable helper and expose it via a lightweight HTTP server
- wire the demo index page with a “Générer les données” button that calls the new /api/seed endpoint
- document the new workflow and npm script in the README

## Testing
- Not run (npm install blocked by registry access restrictions)


------
https://chatgpt.com/codex/tasks/task_e_68dd3c616a80832192455f6d0d76d810