### PR TITLE
feat: render frontend with ejs

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "start": "node src/server.js"
   },
   "dependencies": {
-    "@prisma/client": "^5.16.1"
+    "@prisma/client": "^5.16.1",
+    "ejs": "^3.1.10",
+    "express": "^4.19.2"
   },
   "devDependencies": {
     "prisma": "^5.16.1"

--- a/src/server.js
+++ b/src/server.js
@@ -1,5 +1,4 @@
-const http = require('http');
-const fs = require('fs');
+const express = require('express');
 const path = require('path');
 const { prisma } = require('./db');
 const { seedDatabase } = require('./seedDatabase');
@@ -7,73 +6,42 @@ const { seedDatabase } = require('./seedDatabase');
 const PORT = process.env.PORT ? Number(process.env.PORT) : 3000;
 const ROOT_DIR = path.resolve(__dirname, '..');
 
-function sendJson(res, statusCode, payload) {
-  const body = JSON.stringify(payload);
-  res.writeHead(statusCode, {
-    'Content-Type': 'application/json; charset=utf-8',
-    'Content-Length': Buffer.byteLength(body)
-  });
-  res.end(body);
-}
+const app = express();
 
-function sendFile(res, filePath) {
-  fs.readFile(filePath, (err, data) => {
-    if (err) {
-      res.statusCode = err.code === 'ENOENT' ? 404 : 500;
-      res.end(res.statusCode === 404 ? 'Not found' : 'Internal server error');
-      return;
-    }
-    const ext = path.extname(filePath).toLowerCase();
-    const contentType = {
-      '.html': 'text/html; charset=utf-8',
-      '.js': 'application/javascript; charset=utf-8',
-      '.css': 'text/css; charset=utf-8',
-      '.json': 'application/json; charset=utf-8'
-    }[ext] || 'application/octet-stream';
+app.set('view engine', 'ejs');
+app.set('views', path.join(ROOT_DIR, 'views'));
 
-    res.writeHead(200, { 'Content-Type': contentType });
-    res.end(data);
-  });
-}
-
-const server = http.createServer(async (req, res) => {
-  const { method } = req;
-  const url = new URL(req.url, `http://${req.headers.host}`);
-
-  if (method === 'POST' && url.pathname === '/api/seed') {
-    try {
-      const result = await seedDatabase(prisma);
-      sendJson(res, 200, {
-        status: 'ok',
-        customers: result.customersCreated,
-        orders: result.ordersCreated
-      });
-    } catch (error) {
-      console.error('Failed to seed database', error);
-      sendJson(res, 500, { status: 'error', message: 'Impossible de générer les données.' });
-    }
-    return;
-  }
-
-  if (method === 'GET' && url.pathname === '/api/seed') {
-    sendJson(res, 405, { status: 'error', message: 'Method Not Allowed' });
-    return;
-  }
-
-  if (method === 'GET') {
-    let filePath = path.join(ROOT_DIR, url.pathname);
-    if (url.pathname === '/' || url.pathname === '') {
-      filePath = path.join(ROOT_DIR, 'index.html');
-    }
-    sendFile(res, filePath);
-    return;
-  }
-
-  res.statusCode = 404;
-  res.end('Not found');
+app.get('/mini4GL.js', (req, res) => {
+  res.sendFile(path.join(ROOT_DIR, 'mini4GL.js'));
 });
 
-server.listen(PORT, () => {
+app.post('/api/seed', async (req, res) => {
+  try {
+    const result = await seedDatabase(prisma);
+    res.json({
+      status: 'ok',
+      customers: result.customersCreated,
+      orders: result.ordersCreated
+    });
+  } catch (error) {
+    console.error('Failed to seed database', error);
+    res.status(500).json({ status: 'error', message: 'Impossible de générer les données.' });
+  }
+});
+
+app.get('/api/seed', (req, res) => {
+  res.status(405).json({ status: 'error', message: 'Method Not Allowed' });
+});
+
+app.get('/', (req, res) => {
+  res.render('index');
+});
+
+app.use((req, res) => {
+  res.status(404).send('Not found');
+});
+
+app.listen(PORT, () => {
   console.log(`Mini4GL demo server ready on http://localhost:${PORT}`);
 });
 

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -137,7 +137,7 @@
       </section>
     </main>
 
-    <script src="mini4GL.js"></script>
+    <script src="/mini4GL.js"></script>
     <script>
       const editor = document.getElementById('editor');
       const runBtn = document.getElementById('run');


### PR DESCRIPTION
## Summary
- convert the static landing page into an EJS view so the frontend can be rendered by the Node server
- switch the HTTP server to Express and render the new view while keeping the database seeding API
- declare the Express and EJS dependencies so `npm start` runs the backend and serves the frontend together

## Testing
- not run (npm install blocked by registry access restrictions)


------
https://chatgpt.com/codex/tasks/task_e_68dd42e1d4648321b6cc392bfcfe796a