### PR TITLE
Ensure seed script prepares SQLite schema

### DIFF
--- a/src/seedDatabase.js
+++ b/src/seedDatabase.js
@@ -1,10 +1,46 @@
 const { PrismaClient } = require('@prisma/client');
 
+async function ensureDatabaseSchema(prisma) {
+  const existingTables = await prisma.$queryRaw`SELECT name FROM sqlite_master WHERE type = 'table' AND name IN ('Customer', 'Order')`;
+  const tableSet = new Set(existingTables.map((table) => table.name));
+
+  if (!tableSet.has('Customer')) {
+    await prisma.$executeRawUnsafe(`
+      CREATE TABLE "Customer" (
+        "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+        "name" TEXT NOT NULL,
+        "email" TEXT NOT NULL,
+        "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+      );
+    `);
+    await prisma.$executeRawUnsafe(
+      'CREATE UNIQUE INDEX IF NOT EXISTS "Customer_email_key" ON "Customer"("email");'
+    );
+  }
+
+  if (!tableSet.has('Order')) {
+    await prisma.$executeRawUnsafe(`
+      CREATE TABLE "Order" (
+        "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+        "total" REAL NOT NULL,
+        "status" TEXT NOT NULL,
+        "placedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        "customerId" INTEGER NOT NULL,
+        CONSTRAINT "Order_customerId_fkey" FOREIGN KEY ("customerId") REFERENCES "Customer"("id") ON DELETE RESTRICT ON UPDATE CASCADE
+      );
+    `);
+    await prisma.$executeRawUnsafe(
+      'CREATE INDEX IF NOT EXISTS "Order_customerId_idx" ON "Order"("customerId");'
+    );
+  }
+}
+
 async function seedDatabase(existingClient) {
   const prisma = existingClient ?? new PrismaClient();
   const shouldDisconnect = !existingClient;
 
   try {
+    await ensureDatabaseSchema(prisma);
     await prisma.order.deleteMany();
     await prisma.customer.deleteMany();
 


### PR DESCRIPTION
## Summary
- ensure the seed routine creates the required SQLite tables if they are missing
- continue seeding customers and orders using the Prisma client once the schema exists

## Testing
- npm run seed

------
https://chatgpt.com/codex/tasks/task_e_68dd4489ba788321ba923fde0b7329d6