### PR TITLE
Fix Prisma schema for customer orders

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,35 +8,32 @@ generator client {
 }
 
 model Customer {
-
-  id        Int      @id @default(autoincrement())
-  custNum   String   @unique
-  name      String
-  email     String   @unique
-  city      String?
-  state     String?
-  balance   Float    @default(0)
-  creditLimit Float  @default(0)
-  createdAt DateTime @default(now())
-  orders    Order[]
-}
-
-model Order {
-  id         Int      @id @default(autoincrement())
-  orderNum   String   @unique
-  orderDate  DateTime @default(now())
-  shipDate   DateTime?
-  custNum     Int      @unique
+  id          Int       @id @default(autoincrement())
+  custNum     Int       @unique
   name        String
   contact     String?
   phone       String?
   address     String?
   city        String
-  state       String   @default("NH")
+  state       String    @default("NH")
   postalCode  String?
   balance     Float
   creditLimit Float
-  createdAt   DateTime @default(now())
+  createdAt   DateTime  @default(now())
+
   orders      Order[]
+}
+
+model Order {
+  id          Int       @id @default(autoincrement())
+  orderNum    Int       @unique
+  total       Float
+  status      String
+  orderDate   DateTime  @default(now())
+  shipDate    DateTime?
+  createdAt   DateTime  @default(now())
+
+  customer    Customer  @relation(fields: [customerId], references: [id])
+  customerId  Int
 }
 


### PR DESCRIPTION
## Summary
- align the Customer and Order models around a proper customer relation and order metadata
- update the seed helper to create the expected tables and populate customers/orders from the shared dataset

## Testing
- npx prisma validate
- npm run seed

------
https://chatgpt.com/codex/tasks/task_e_68dd4a0ffef083219308b8f51fa9a11b