### PR TITLE
Handle unknown literal and await interpreter execution

### DIFF
--- a/mini4GL.js
+++ b/mini4GL.js
@@ -71,6 +71,7 @@
       // comments: /* ... */ and // ...
       if(ch==='/' && src[i+1]==='*'){ i+=2; while(i<n && !(src[i]==='*' && src[i+1]==='/')) i++; i+=2; continue; }
       if(ch==='/' && src[i+1]==='/'){ i+=2; while(i<n && src[i]!=="\n") i++; continue; }
+      if(ch==='?'){ push('UNKNOWN', null); i++; continue; }
       // strings: "..."
       if(ch==='"'){
         i++; let start=i; let s=""; let esc=false;
@@ -529,6 +530,7 @@
       }
       return { type:'Var', name:segments[0].toLowerCase() };
     }
+    if(this.match('UNKNOWN')){ return { type:'Unknown' }; }
     if(this.match('LPAREN')){ const e=this.parseExpr(); this.eat('RPAREN'); return e; }
     throw new SyntaxError(`Unexpected token in expression: ${t.type}`);
   };
@@ -904,6 +906,7 @@
         if(env.records && Object.prototype.hasOwnProperty.call(env.records, node.name)) return env.records[node.name];
         return null;
       }
+      case 'Unknown': return null;
       case 'Field': return resolveFieldValue(node.path, env);
       case 'Unary':{
         const v=evalExpr(node.arg, env);

--- a/test.js
+++ b/test.js
@@ -13,6 +13,28 @@ const tests = [
     }
   },
   {
+    name: 'Question mark literal represents unknown values in comparisons',
+    program: `
+      DEFINE VARIABLE shipDate AS CHARACTER NO-UNDO INIT ?.
+      DEFINE VARIABLE statusMessage AS CHARACTER NO-UNDO INIT "aucune".
+
+      IF shipDate NE ? THEN
+        ASSIGN statusMessage = "devrait rester vide".
+      END.
+
+      ASSIGN shipDate = "2024-05-01".
+
+      IF shipDate NE ? THEN
+        ASSIGN statusMessage = "expédié".
+      END.
+
+      DISPLAY statusMessage.
+    `,
+    verify: ({ output }) => {
+      assert.deepStrictEqual(output, ['expédié']);
+    }
+  },
+  {
     name: 'ENTRY splits lists with default and custom delimiters',
     program: `
       DISPLAY ENTRY(2, "alpha,beta,gamma").

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -179,13 +179,13 @@
         statusEl.style.color = isError ? '#ff7373' : '#8be9fd';
       }
 
-      runBtn.addEventListener('click', () => {
+      runBtn.addEventListener('click', async () => {
         clearOutput();
         setStatus('Exécution...');
         const source = editor.value;
         try {
           const start = performance.now();
-          const result = Mini4GL.interpret4GL(source, {
+          const result = await Mini4GL.interpret4GL(source, {
             onOutput: appendOutput,
           });
           const duration = (performance.now() - start).toFixed(2);


### PR DESCRIPTION
## Summary
- allow the tokenizer and evaluator to treat the question mark literal as an unknown value
- extend the browser runner to await the interpreter so async errors surface correctly
- add a regression test covering comparisons with the unknown literal

## Testing
- node test.js

------
https://chatgpt.com/codex/tasks/task_e_68de0d314acc83219dce922a65f907cc