### PR TITLE
Allow DISPLAY parsing without commas between expressions

### DIFF
--- a/mini4GL.js
+++ b/mini4GL.js
@@ -271,6 +271,14 @@
     return { id:id.toLowerCase(), dataType, init, noUndo };
   };
 
+  function isExprStartToken(tok){
+    if(!tok) return false;
+    if(['IDENT','NUMBER','STRING','UNKNOWN','LPAREN'].includes(tok.type)) return true;
+    if(tok.type==='OP' && (tok.value==='+' || tok.value==='-')) return true;
+    if(tok.type==='NOT') return true;
+    return false;
+  }
+
   Parser.prototype.parseDisplay=function(){
     this.eat(this.peek().type); // DISPLAY or PRINT
     const items=[];
@@ -292,7 +300,10 @@
         break;
       }
       items.push(meta);
-      if(!this.match('COMMA')) break;
+      if(this.match('COMMA')) continue;
+      const next=this.peek();
+      if(isExprStartToken(next)) continue;
+      break;
     }
     const withOptions=[];
     if(this.match('WITH')){

--- a/test.js
+++ b/test.js
@@ -58,6 +58,18 @@ const tests = [
     }
   },
   {
+    name: 'DISPLAY allows multiple expressions without commas',
+    program: `
+      DEFINE VARIABLE custNum AS INTEGER INIT 7.
+      DEFINE VARIABLE fullName AS CHARACTER INIT "Robin".
+      DEFINE VARIABLE city AS CHARACTER INIT "Concord".
+      DISPLAY custNum fullName city.
+    `,
+    verify: ({ output }) => {
+      assert.deepStrictEqual(output, ['7 Robin Concord']);
+    }
+  },
+  {
     name: 'RUN executes procedures with INPUT and OUTPUT parameters',
     program: `
       PROCEDURE calcDays:


### PR DESCRIPTION
## Summary
- allow DISPLAY/PRINT statements to treat whitespace-separated expressions as distinct items
- add a regression test covering DISPLAY usage without commas

## Testing
- node test.js

------
https://chatgpt.com/codex/tasks/task_e_68de4c503b888321b10fe3fefc4f72d9