### PR TITLE
Ensure Prisma schema exists before running interpreter

### DIFF
--- a/src/db.js
+++ b/src/db.js
@@ -1,6 +1,8 @@
 const { PrismaClient } = require('@prisma/client');
+const { ensureDatabaseSchema } = require('./seedDatabase');
 
 let prismaInstance = null;
+let schemaInitializationPromise = null;
 
 function getPrismaClient() {
   if (!prismaInstance) {
@@ -9,6 +11,18 @@ function getPrismaClient() {
   return prismaInstance;
 }
 
+function ensurePrismaReady() {
+  if (!schemaInitializationPromise) {
+    const client = getPrismaClient();
+    schemaInitializationPromise = ensureDatabaseSchema(client).catch((error) => {
+      schemaInitializationPromise = null;
+      throw error;
+    });
+  }
+  return schemaInitializationPromise;
+}
+
 module.exports = {
-  prisma: getPrismaClient()
+  prisma: getPrismaClient(),
+  ensurePrismaReady
 };

--- a/src/seedDatabase.js
+++ b/src/seedDatabase.js
@@ -198,6 +198,7 @@ async function seedDatabase(existingClient) {
 }
 
 module.exports = {
-  seedDatabase
+  seedDatabase,
+  ensureDatabaseSchema
 };
 

--- a/src/server.js
+++ b/src/server.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const path = require('path');
 const { interpret4GL } = require('../mini4GL.js');
-const { prisma } = require('./db');
+const { prisma, ensurePrismaReady } = require('./db');
 const { seedDatabase } = require('./seedDatabase');
 
 const PORT = process.env.PORT ? Number(process.env.PORT) : 3000;
@@ -29,9 +29,12 @@ app.post('/api/run', async (req, res) => {
   const sanitizedInputs = Array.isArray(inputs) ? inputs.slice(0, 64) : [];
 
   try {
+    const prismaReadyPromise = ensurePrismaReady();
+    await prismaReadyPromise;
     const result = await interpret4GL(source, {
       prisma,
-      inputs: sanitizedInputs
+      inputs: sanitizedInputs,
+      prismaReady: prismaReadyPromise
     });
     res.json({ status: 'ok', output: result.output });
   } catch (error) {


### PR DESCRIPTION
## Summary
- ensure the Prisma schema is initialized before interpreter queries run
- expose the schema bootstrap helper and await it in the server and interpreter

## Testing
- node test.js

------
https://chatgpt.com/codex/tasks/task_e_68de4d8a2db08321bb46439096965573