### PR TITLE
Document Prisma datasource provider requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,16 @@ sqlite3 prisma/sport2000.db ".backup 'backups/sport2000-$(date +%Y%m%d%H%M%S).db
 ```
 
 La commande crée un répertoire `backups/` (s'il n'existe pas) et y stocke une copie horodatée de la base. Vous pouvez ensuite restaurer la sauvegarde souhaitée avec `sqlite3` si nécessaire.
+
+### Configuration Prisma
+
+Le fichier [`prisma/schema.prisma`](./prisma/schema.prisma) est configuré pour utiliser SQLite par défaut :
+
+```prisma
+datasource db {
+  provider = "sqlite"
+  url      = "file:./sport2000.db"
+}
+```
+
+Le champ `provider` doit impérativement rester une chaîne de caractères littérale pour que `npx prisma generate` fonctionne (`Error code: P1012` dans le cas contraire). Si vous souhaitez utiliser un autre SGBD, remplacez simplement `"sqlite"` par le fournisseur approprié (`"postgresql"`, `"mysql"`, etc.) au lieu d'essayer de lister plusieurs options.


### PR DESCRIPTION
## Summary
- document the default Prisma datasource configuration used by the project
- explain that the `provider` value must remain a single string literal and how to change it safely

## Testing
- npm exec prisma generate

------
https://chatgpt.com/codex/tasks/task_e_68de63809d488321bcaae95ab33a8f4c