### PR TITLE
Expand sports2000 seed dataset

### DIFF
--- a/src/seedDatabase.js
+++ b/src/seedDatabase.js
@@ -18,6 +18,78 @@ const customerSeedData = [
     city: 'Brest',
     country: 'France',
     phone: '+33 2 98 56 12 34'
+  },
+  {
+    name: 'Paris Cyclisme',
+    city: 'Paris',
+    country: 'France',
+    phone: '+33 1 53 02 45 87'
+  },
+  {
+    name: 'Méditerranée Plongée',
+    city: 'Marseille',
+    country: 'France',
+    phone: '+33 4 91 12 67 50'
+  },
+  {
+    name: 'Nordic Ski Shop',
+    city: 'Chambéry',
+    country: 'France',
+    phone: '+33 4 79 22 45 18'
+  },
+  {
+    name: 'Languedoc Rando',
+    city: 'Montpellier',
+    country: 'France',
+    phone: '+33 4 67 45 67 10'
+  },
+  {
+    name: 'Provence Escalade',
+    city: 'Avignon',
+    country: 'France',
+    phone: '+33 4 90 12 78 45'
+  },
+  {
+    name: 'Bordeaux Golf Club',
+    city: 'Bordeaux',
+    country: 'France',
+    phone: '+33 5 56 47 89 12'
+  },
+  {
+    name: 'Nice Fitness',
+    city: 'Nice',
+    country: 'France',
+    phone: '+33 4 93 27 54 01'
+  },
+  {
+    name: 'Toulouse Kayak',
+    city: 'Toulouse',
+    country: 'France',
+    phone: '+33 5 61 45 12 99'
+  },
+  {
+    name: 'Strasbourg Hockey',
+    city: 'Strasbourg',
+    country: 'France',
+    phone: '+33 3 88 45 78 33'
+  },
+  {
+    name: 'Marseille Vélo',
+    city: 'Marseille',
+    country: 'France',
+    phone: '+33 4 91 30 22 11'
+  },
+  {
+    name: 'Lille Running',
+    city: 'Lille',
+    country: 'France',
+    phone: '+33 3 20 12 57 84'
+  },
+  {
+    name: 'Corsica Aventure',
+    city: 'Ajaccio',
+    country: 'France',
+    phone: '+33 4 95 20 31 55'
   }
 ];
 
@@ -33,6 +105,18 @@ const salesmanSeedData = [
   {
     name: 'Sofia Martins',
     region: 'Bretagne'
+  },
+  {
+    name: 'Julien Caradec',
+    region: 'Nouvelle-Aquitaine'
+  },
+  {
+    name: 'Laura Chen',
+    region: 'Occitanie'
+  },
+  {
+    name: 'Amine Haddad',
+    region: 'Provence-Alpes-Côte d’Azur'
   }
 ];
 
@@ -61,6 +145,81 @@ const itemSeedData = [
     name: 'Grip Performance',
     category: 'Accessoires',
     price: 8.5
+  },
+  {
+    name: 'Vélo route AeroSonic 500',
+    category: 'Cyclisme',
+    price: 2399.0
+  },
+  {
+    name: 'Casque VTT PeakGuard',
+    category: 'Cyclisme',
+    price: 89.9
+  },
+  {
+    name: 'Sac à dos Trek Explorer 45L',
+    category: 'Randonnée',
+    price: 159.0
+  },
+  {
+    name: 'Tente Alpinist 2P',
+    category: 'Camping',
+    price: 499.0
+  },
+  {
+    name: 'Planche de snowboard Glacier Edge',
+    category: 'Sports d’hiver',
+    price: 399.0
+  },
+  {
+    name: 'Ski nordique Borealis',
+    category: 'Ski',
+    price: 299.0
+  },
+  {
+    name: 'Chaussures de ski Borealis Pro',
+    category: 'Ski',
+    price: 249.0
+  },
+  {
+    name: 'Gants de gardien UltraGrip',
+    category: 'Football',
+    price: 64.0
+  },
+  {
+    name: 'Ballon de football ElitePro',
+    category: 'Football',
+    price: 55.0
+  },
+  {
+    name: 'Palmes BlueReef',
+    category: 'Plongée',
+    price: 74.5
+  },
+  {
+    name: 'Combinaison de plongée Abyss 5mm',
+    category: 'Plongée',
+    price: 329.0
+  },
+  {
+    name: 'Montre GPS TrailMaster',
+    category: 'Accessoires',
+    price: 219.0
+  },
+  {
+    name: 'Rack d’haltères PowerStack',
+    category: 'Fitness',
+    price: 799.0
+  },
+  {
+    name: 'Stand-up paddle Lago 11',
+    category: 'Nautisme',
+    price: 899.0
+  },
+  {
+    name: 'Gants d’escalade GripMax',
+    category: 'Escalade',
+    price: 32.0
   }
 ];
 
@@ -88,7 +247,8 @@ const orderSeedData = [
     customer: 'Bretagne Nautique',
     salesman: 'Sofia Martins',
     lines: [
-      { item: 'Combinaison de surf Atlantik 4/3', quantity: 4, price: 249.0 }
+      { item: 'Combinaison de surf Atlantik 4/3', quantity: 4, price: 249.0 },
+      { item: 'Stand-up paddle Lago 11', quantity: 2, price: 899.0 }
     ]
   },
   {
@@ -98,6 +258,108 @@ const orderSeedData = [
     lines: [
       { item: 'Ballon de basket StreetMaster', quantity: 10, price: 37.0 },
       { item: 'Grip Performance', quantity: 12, price: 7.9 }
+    ]
+  },
+  {
+    orderDate: new Date('2024-05-28T00:00:00Z'),
+    customer: 'Paris Cyclisme',
+    salesman: 'Isabelle Laurent',
+    lines: [
+      { item: 'Vélo route AeroSonic 500', quantity: 3, price: 2299.0 },
+      { item: 'Casque VTT PeakGuard', quantity: 5, price: 85.0 }
+    ]
+  },
+  {
+    orderDate: new Date('2024-06-02T00:00:00Z'),
+    customer: 'Méditerranée Plongée',
+    salesman: 'Sofia Martins',
+    lines: [
+      { item: 'Combinaison de plongée Abyss 5mm', quantity: 6, price: 319.0 },
+      { item: 'Palmes BlueReef', quantity: 10, price: 69.9 }
+    ]
+  },
+  {
+    orderDate: new Date('2024-06-08T00:00:00Z'),
+    customer: 'Nordic Ski Shop',
+    salesman: 'Julien Caradec',
+    lines: [
+      { item: 'Ski nordique Borealis', quantity: 8, price: 289.0 },
+      { item: 'Chaussures de ski Borealis Pro', quantity: 8, price: 239.0 },
+      { item: 'Planche de snowboard Glacier Edge', quantity: 4, price: 379.0 }
+    ]
+  },
+  {
+    orderDate: new Date('2024-06-14T00:00:00Z'),
+    customer: 'Languedoc Rando',
+    salesman: 'Laura Chen',
+    lines: [
+      { item: 'Sac à dos Trek Explorer 45L', quantity: 12, price: 149.0 },
+      { item: 'Tente Alpinist 2P', quantity: 4, price: 479.0 },
+      { item: 'Montre GPS TrailMaster', quantity: 6, price: 209.0 }
+    ]
+  },
+  {
+    orderDate: new Date('2024-06-20T00:00:00Z'),
+    customer: 'Provence Escalade',
+    salesman: 'Amine Haddad',
+    lines: [
+      { item: 'Gants d’escalade GripMax', quantity: 30, price: 29.5 },
+      { item: 'Sac à dos Trek Explorer 45L', quantity: 5, price: 155.0 }
+    ]
+  },
+  {
+    orderDate: new Date('2024-06-27T00:00:00Z'),
+    customer: 'Bordeaux Golf Club',
+    salesman: 'Marc Dubois',
+    lines: [
+      { item: 'Rack d’haltères PowerStack', quantity: 2, price: 749.0 },
+      { item: 'Montre GPS TrailMaster', quantity: 3, price: 215.0 }
+    ]
+  },
+  {
+    orderDate: new Date('2024-07-03T00:00:00Z'),
+    customer: 'Nice Fitness',
+    salesman: 'Amine Haddad',
+    lines: [
+      { item: 'Rack d’haltères PowerStack', quantity: 3, price: 779.0 },
+      { item: 'Ballon de basket StreetMaster', quantity: 20, price: 35.0 }
+    ]
+  },
+  {
+    orderDate: new Date('2024-07-09T00:00:00Z'),
+    customer: 'Toulouse Kayak',
+    salesman: 'Laura Chen',
+    lines: [
+      { item: 'Stand-up paddle Lago 11', quantity: 4, price: 869.0 },
+      { item: 'Sac à dos Trek Explorer 45L', quantity: 6, price: 152.0 }
+    ]
+  },
+  {
+    orderDate: new Date('2024-07-18T00:00:00Z'),
+    customer: 'Strasbourg Hockey',
+    salesman: 'Isabelle Laurent',
+    lines: [
+      { item: 'Gants de gardien UltraGrip', quantity: 15, price: 60.0 },
+      { item: 'Ballon de football ElitePro', quantity: 12, price: 49.5 }
+    ]
+  },
+  {
+    orderDate: new Date('2024-07-24T00:00:00Z'),
+    customer: 'Lille Running',
+    salesman: 'Julien Caradec',
+    lines: [
+      { item: 'Chaussures de trail Alpina X', quantity: 12, price: 119.0 },
+      { item: 'Montre GPS TrailMaster', quantity: 8, price: 205.0 }
+    ]
+  },
+  {
+    orderDate: new Date('2024-07-30T00:00:00Z'),
+    customer: 'Corsica Aventure',
+    salesman: 'Sofia Martins',
+    lines: [
+      { item: 'Tente Alpinist 2P', quantity: 3, price: 489.0 },
+      { item: 'Stand-up paddle Lago 11', quantity: 1, price: 879.0 },
+      { item: 'Sac à dos Trek Explorer 45L', quantity: 4, price: 150.0 }
     ]
   }
 ];


### PR DESCRIPTION
## Summary
- expand the sport2000 seed data with additional customers, salespeople, items, and orders
- ensure every table is populated with richer sample data for demos

## Testing
- npm run seed

------
https://chatgpt.com/codex/tasks/task_e_68de6c688a808321bb2ad2e0229b9ea2