### PR TITLE
Fix browser redeclaration errors in statement modules

### DIFF
--- a/src/mini4gl/statements/assign.js
+++ b/src/mini4gl/statements/assign.js
@@ -16,7 +16,7 @@ function executeAssign(node, env, context) {
   context.setVar(env, node.id, context.evalExpr(node.value, env));
 }
 
-const exported = {
+const assignStatement = {
   keywords: ['ASSIGN'],
   allowIdentifierStart: true,
   parse: parseAssign,
@@ -26,7 +26,7 @@ const exported = {
 };
 
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = exported;
+  module.exports = assignStatement;
 } else {
   const globalScope =
     typeof globalThis !== 'undefined'
@@ -37,5 +37,5 @@ if (typeof module !== 'undefined' && module.exports) {
           ? global
           : {};
   globalScope.Mini4GLStatementModules = globalScope.Mini4GLStatementModules || [];
-  globalScope.Mini4GLStatementModules.push(exported);
+  globalScope.Mini4GLStatementModules.push(assignStatement);
 }

--- a/src/mini4gl/statements/define.js
+++ b/src/mini4gl/statements/define.js
@@ -73,7 +73,7 @@ function executeDefineParameter() {
   // Parameters are handled at procedure invocation time.
 }
 
-const exported = {
+const defineStatement = {
   keywords: ['DEFINE'],
   parse: parseDefine,
   executors: {
@@ -83,7 +83,7 @@ const exported = {
 };
 
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = exported;
+  module.exports = defineStatement;
 } else {
   const globalScope =
     typeof globalThis !== 'undefined'
@@ -94,5 +94,5 @@ if (typeof module !== 'undefined' && module.exports) {
           ? global
           : {};
   globalScope.Mini4GLStatementModules = globalScope.Mini4GLStatementModules || [];
-  globalScope.Mini4GLStatementModules.push(exported);
+  globalScope.Mini4GLStatementModules.push(defineStatement);
 }

--- a/src/mini4gl/statements/display.js
+++ b/src/mini4gl/statements/display.js
@@ -83,7 +83,7 @@ function executeDisplay(node, env, context) {
   env.output(line);
 }
 
-const exported = {
+const displayStatement = {
   keywords: ['DISPLAY', 'PRINT'],
   parse: parseDisplay,
   executors: {
@@ -92,7 +92,7 @@ const exported = {
 };
 
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = exported;
+  module.exports = displayStatement;
 } else {
   const globalScope =
     typeof globalThis !== 'undefined'
@@ -103,5 +103,5 @@ if (typeof module !== 'undefined' && module.exports) {
           ? global
           : {};
   globalScope.Mini4GLStatementModules = globalScope.Mini4GLStatementModules || [];
-  globalScope.Mini4GLStatementModules.push(exported);
+  globalScope.Mini4GLStatementModules.push(displayStatement);
 }

--- a/src/mini4gl/statements/do.js
+++ b/src/mini4gl/statements/do.js
@@ -23,7 +23,7 @@ async function executeDo(node, env, context) {
   }
 }
 
-const exported = {
+const doStatement = {
   keywords: ['DO'],
   parse: parseDo,
   executors: {
@@ -32,7 +32,7 @@ const exported = {
 };
 
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = exported;
+  module.exports = doStatement;
 } else {
   const globalScope =
     typeof globalThis !== 'undefined'
@@ -43,5 +43,5 @@ if (typeof module !== 'undefined' && module.exports) {
           ? global
           : {};
   globalScope.Mini4GLStatementModules = globalScope.Mini4GLStatementModules || [];
-  globalScope.Mini4GLStatementModules.push(exported);
+  globalScope.Mini4GLStatementModules.push(doStatement);
 }

--- a/src/mini4gl/statements/find.js
+++ b/src/mini4gl/statements/find.js
@@ -72,7 +72,7 @@ async function executeFind(node, env, context) {
   env.vars[targetLower] = record;
 }
 
-const exported = {
+const findStatement = {
   keywords: ['FIND'],
   parse: parseFind,
   executors: {
@@ -81,7 +81,7 @@ const exported = {
 };
 
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = exported;
+  module.exports = findStatement;
 } else {
   const globalScope =
     typeof globalThis !== 'undefined'
@@ -92,5 +92,5 @@ if (typeof module !== 'undefined' && module.exports) {
           ? global
           : {};
   globalScope.Mini4GLStatementModules = globalScope.Mini4GLStatementModules || [];
-  globalScope.Mini4GLStatementModules.push(exported);
+  globalScope.Mini4GLStatementModules.push(findStatement);
 }

--- a/src/mini4gl/statements/forEach.js
+++ b/src/mini4gl/statements/forEach.js
@@ -126,7 +126,7 @@ async function executeForEach(node, env, context) {
   }
 }
 
-const exported = {
+const forEachStatement = {
   keywords: ['FOR'],
   parse: parseForEach,
   executors: {
@@ -135,7 +135,7 @@ const exported = {
 };
 
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = exported;
+  module.exports = forEachStatement;
 } else {
   const globalScope =
     typeof globalThis !== 'undefined'
@@ -146,5 +146,5 @@ if (typeof module !== 'undefined' && module.exports) {
           ? global
           : {};
   globalScope.Mini4GLStatementModules = globalScope.Mini4GLStatementModules || [];
-  globalScope.Mini4GLStatementModules.push(exported);
+  globalScope.Mini4GLStatementModules.push(forEachStatement);
 }

--- a/src/mini4gl/statements/if.js
+++ b/src/mini4gl/statements/if.js
@@ -20,7 +20,7 @@ async function executeIf(node, env, context) {
   }
 }
 
-const exported = {
+const ifStatement = {
   keywords: ['IF'],
   parse: parseIf,
   executors: {
@@ -29,7 +29,7 @@ const exported = {
 };
 
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = exported;
+  module.exports = ifStatement;
 } else {
   const globalScope =
     typeof globalThis !== 'undefined'
@@ -40,5 +40,5 @@ if (typeof module !== 'undefined' && module.exports) {
           ? global
           : {};
   globalScope.Mini4GLStatementModules = globalScope.Mini4GLStatementModules || [];
-  globalScope.Mini4GLStatementModules.push(exported);
+  globalScope.Mini4GLStatementModules.push(ifStatement);
 }

--- a/src/mini4gl/statements/input.js
+++ b/src/mini4gl/statements/input.js
@@ -12,7 +12,7 @@ function executeInput(node, env, context) {
   context.setVar(env, node.id, value);
 }
 
-const exported = {
+const inputStatement = {
   keywords: ['INPUT'],
   parse: parseInput,
   executors: {
@@ -21,7 +21,7 @@ const exported = {
 };
 
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = exported;
+  module.exports = inputStatement;
 } else {
   const globalScope =
     typeof globalThis !== 'undefined'
@@ -32,5 +32,5 @@ if (typeof module !== 'undefined' && module.exports) {
           ? global
           : {};
   globalScope.Mini4GLStatementModules = globalScope.Mini4GLStatementModules || [];
-  globalScope.Mini4GLStatementModules.push(exported);
+  globalScope.Mini4GLStatementModules.push(inputStatement);
 }

--- a/src/mini4gl/statements/procedure.js
+++ b/src/mini4gl/statements/procedure.js
@@ -46,7 +46,7 @@ function executeProcedure(node, env) {
   env.procedures[node.name] = node;
 }
 
-const exported = {
+const procedureStatement = {
   keywords: ['PROCEDURE'],
   parse: parseProcedure,
   executors: {
@@ -55,7 +55,7 @@ const exported = {
 };
 
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = exported;
+  module.exports = procedureStatement;
 } else {
   const globalScope =
     typeof globalThis !== 'undefined'
@@ -66,5 +66,5 @@ if (typeof module !== 'undefined' && module.exports) {
           ? global
           : {};
   globalScope.Mini4GLStatementModules = globalScope.Mini4GLStatementModules || [];
-  globalScope.Mini4GLStatementModules.push(exported);
+  globalScope.Mini4GLStatementModules.push(procedureStatement);
 }

--- a/src/mini4gl/statements/repeat.js
+++ b/src/mini4gl/statements/repeat.js
@@ -22,7 +22,7 @@ async function executeRepeat(node, env, context) {
   }
 }
 
-const exported = {
+const repeatStatement = {
   keywords: ['REPEAT'],
   parse: parseRepeat,
   executors: {
@@ -31,7 +31,7 @@ const exported = {
 };
 
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = exported;
+  module.exports = repeatStatement;
 } else {
   const globalScope =
     typeof globalThis !== 'undefined'
@@ -42,5 +42,5 @@ if (typeof module !== 'undefined' && module.exports) {
           ? global
           : {};
   globalScope.Mini4GLStatementModules = globalScope.Mini4GLStatementModules || [];
-  globalScope.Mini4GLStatementModules.push(exported);
+  globalScope.Mini4GLStatementModules.push(repeatStatement);
 }

--- a/src/mini4gl/statements/run.js
+++ b/src/mini4gl/statements/run.js
@@ -29,7 +29,7 @@ function executeRun(node, env, context) {
   return context.runProcedure(node, env);
 }
 
-const exported = {
+const runStatement = {
   keywords: ['RUN'],
   parse: parseRun,
   executors: {
@@ -38,7 +38,7 @@ const exported = {
 };
 
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = exported;
+  module.exports = runStatement;
 } else {
   const globalScope =
     typeof globalThis !== 'undefined'
@@ -49,5 +49,5 @@ if (typeof module !== 'undefined' && module.exports) {
           ? global
           : {};
   globalScope.Mini4GLStatementModules = globalScope.Mini4GLStatementModules || [];
-  globalScope.Mini4GLStatementModules.push(exported);
+  globalScope.Mini4GLStatementModules.push(runStatement);
 }

--- a/src/mini4gl/statements/while.js
+++ b/src/mini4gl/statements/while.js
@@ -17,7 +17,7 @@ async function executeWhile(node, env, context) {
   }
 }
 
-const exported = {
+const whileStatement = {
   keywords: ['WHILE'],
   parse: parseWhile,
   executors: {
@@ -26,7 +26,7 @@ const exported = {
 };
 
 if (typeof module !== 'undefined' && module.exports) {
-  module.exports = exported;
+  module.exports = whileStatement;
 } else {
   const globalScope =
     typeof globalThis !== 'undefined'
@@ -37,5 +37,5 @@ if (typeof module !== 'undefined' && module.exports) {
           ? global
           : {};
   globalScope.Mini4GLStatementModules = globalScope.Mini4GLStatementModules || [];
-  globalScope.Mini4GLStatementModules.push(exported);
+  globalScope.Mini4GLStatementModules.push(whileStatement);
 }


### PR DESCRIPTION
## Summary
- rename each statement module export to a unique identifier to avoid redeclaration in browser bundles
- update the browser global registration to use the new identifiers

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68debed4826883218e6980ec01f45bdc