### PR TITLE
Improve IF statement parsing

### DIFF
--- a/src/mini4gl/statements/if.js
+++ b/src/mini4gl/statements/if.js
@@ -6,9 +6,11 @@ function parseIf(parser) {
   parser.eat('THEN');
   const consequent = parser.parsePossiblyBlock();
   let alternate = null;
-  if (parser.match('ELSE')) {
+  if (parser.peek().type === 'ELSE') {
+    parser.eat('ELSE');
     alternate = parser.parsePossiblyBlock();
   }
+  parser.optionalDot();
   return { type: 'If', test, consequent, alternate };
 }
 


### PR DESCRIPTION
## Summary
- ensure the IF parser explicitly consumes ELSE before parsing the alternate branch
- allow an optional trailing period after an IF statement to match 4GL syntax expectations

## Testing
- node -e "const { interpret4GL } = require('./mini4GL'); (async () => { const res = await interpret4GL('IF 1 = 0 THEN DISPLAY \\"YES\\" ELSE DISPLAY \\"NO\\".', { inputs: [] }); console.log(res.output); })();"

------
https://chatgpt.com/codex/tasks/task_e_68dec41447d48321bae4e39537085565