### PR TITLE
Implement richer PROCEDURE statement handling

### DIFF
--- a/mini4GL.js
+++ b/mini4GL.js
@@ -93,7 +93,18 @@
     'PARAMETER',
     'OUTPUT',
     'DESCENDING',
-    'BREAK'
+    'BREAK',
+    'PRIVATE',
+    'EXTERNAL',
+    'IN',
+    'SUPER',
+    'ORDINAL',
+    'PERSISTENT',
+    'THREAD',
+    'SAFE',
+    'CDECL',
+    'PASCAL',
+    'STDCALL'
   ]);
 
   const statementRegistry = (typeof require === 'function'
@@ -952,6 +963,29 @@
       throw new Error(`Unknown procedure ${node.name}`);
     }
     const proc=env.procedures[node.name];
+    if(proc.external){
+      throw new Error(`External procedure ${proc.name || node.name} is not supported in this runtime`);
+    }
+    if(proc.inSuper){
+      throw new Error(`Procedure ${proc.name || node.name} declared IN SUPER is not supported`);
+    }
+    if(proc.prototypeOnly){
+      throw new Error(`Procedure ${proc.name || node.name} is declared without an executable body`);
+    }
+    if(proc.isPrivate){
+      let currentEnv = env;
+      let allowed = false;
+      while(currentEnv){
+        if(currentEnv === proc.ownerEnv){
+          allowed = true;
+          break;
+        }
+        currentEnv = currentEnv.parent || null;
+      }
+      if(!allowed){
+        throw new Error(`Procedure ${proc.name || node.name} is PRIVATE and cannot be run from this context`);
+      }
+    }
     const localEnv={
       vars:Object.create(null),
       varDefs:Object.create(null),

--- a/src/mini4gl/statements/procedure.js
+++ b/src/mini4gl/statements/procedure.js
@@ -3,27 +3,117 @@
 function parseProcedure(parser) {
   parser.eat('PROCEDURE');
   const name = parser.eat('IDENT').value.toLowerCase();
-  parser.match('COLON');
-  const body = [];
-  const parameters = [];
-  while (true) {
-    const next = parser.peek();
-    if (next.type === 'EOF') {
-      throw new SyntaxError(`Unexpected EOF inside PROCEDURE ${name}`);
+
+  let isPrivate = false;
+  let external = null;
+  let inSuper = false;
+
+  const takeKeyword = (keyword) => {
+    const tok = parser.peek();
+    if (!tok) {
+      return false;
     }
-    if (next.type === 'END') {
-      const lookahead = parser.toks[parser.i + 1];
-      if (lookahead && lookahead.type === 'PROCEDURE') {
-        parser.eat('END');
-        parser.eat('PROCEDURE');
-        parser.optionalDot();
-        break;
-      }
+    if (tok.type === keyword) {
+      parser.eat(keyword);
+      return true;
     }
-    if (parser.match('DOT')) {
+    if (tok.type === 'IDENT' && String(tok.value).toUpperCase() === keyword) {
+      parser.eat('IDENT');
+      return true;
+    }
+    return false;
+  };
+
+  const parseThreadSafe = () => {
+    if (!takeKeyword('THREAD')) {
+      return false;
+    }
+    const maybeDash = parser.peek();
+    if (maybeDash && maybeDash.type === 'OP' && maybeDash.value === '-') {
+      parser.eat('OP');
+    }
+    if (!takeKeyword('SAFE')) {
+      throw new SyntaxError('Expected SAFE after THREAD-');
+    }
+    return true;
+  };
+
+  let parsingHeader = true;
+  while (parsingHeader) {
+    const tok = parser.peek();
+    if (!tok) {
+      break;
+    }
+    if (!isPrivate && takeKeyword('PRIVATE')) {
+      isPrivate = true;
       continue;
     }
-    const stmt = parser.parseStatement();
+    if (!external && !inSuper && takeKeyword('EXTERNAL')) {
+      const libraryTok = parser.peek();
+      if (libraryTok.type !== 'STRING') {
+        throw new SyntaxError('Expected string literal after EXTERNAL');
+      }
+      const library = parser.eat('STRING').value;
+      let callingConvention = null;
+      const conventionTok = parser.peek();
+      if (conventionTok && ['CDECL', 'PASCAL', 'STDCALL'].includes(conventionTok.type)) {
+        callingConvention = parser.eat(conventionTok.type).type;
+      }
+      let ordinal = null;
+      if (takeKeyword('ORDINAL')) {
+        const ordTok = parser.peek();
+        if (ordTok.type !== 'NUMBER') {
+          throw new SyntaxError('Expected numeric literal after ORDINAL');
+        }
+        ordinal = parser.eat('NUMBER').value;
+      }
+      const persistent = takeKeyword('PERSISTENT');
+      const threadSafe = parseThreadSafe();
+      external = {
+        library,
+        callingConvention,
+        ordinal,
+        persistent,
+        threadSafe
+      };
+      continue;
+    }
+    if (!external && !inSuper && takeKeyword('IN')) {
+      if (!takeKeyword('SUPER')) {
+        throw new SyntaxError('Expected SUPER after IN');
+      }
+      inSuper = true;
+      continue;
+    }
+    parsingHeader = false;
+  }
+
+  let prototypeOnly = false;
+  let statements = [];
+  if (parser.match('COLON')) {
+    statements = parser.parseBlockStatements();
+    parser.eat('END');
+    const maybeProcedureTok = parser.peek();
+    if (
+      maybeProcedureTok &&
+      (maybeProcedureTok.type === 'PROCEDURE' ||
+        (maybeProcedureTok.type === 'IDENT' && String(maybeProcedureTok.value).toUpperCase() === 'PROCEDURE'))
+    ) {
+      parser.eat(maybeProcedureTok.type);
+    }
+    parser.optionalDot();
+  } else if (parser.match('DOT')) {
+    prototypeOnly = true;
+  } else {
+    throw new SyntaxError('Expected : or . after PROCEDURE header');
+  }
+
+  const parameters = [];
+  const body = [];
+  for (const stmt of statements) {
+    if (!stmt) {
+      continue;
+    }
     if (stmt.type === 'DefineParameter') {
       parameters.push({
         name: stmt.id,
@@ -34,16 +124,38 @@ function parseProcedure(parser) {
       });
       continue;
     }
-    body.push(stmt);
+    if (stmt.type !== 'Empty') {
+      body.push(stmt);
+    }
   }
-  return { type: 'Procedure', name, parameters, body };
+
+  return {
+    type: 'Procedure',
+    name,
+    parameters,
+    body,
+    isPrivate,
+    external,
+    inSuper,
+    prototypeOnly
+  };
 }
 
 function executeProcedure(node, env) {
   if (!env.procedures) {
     env.procedures = Object.create(null);
   }
-  env.procedures[node.name] = node;
+  env.procedures[node.name] = {
+    type: 'Procedure',
+    name: node.name,
+    parameters: Array.isArray(node.parameters) ? node.parameters : [],
+    body: Array.isArray(node.body) ? node.body : [],
+    isPrivate: !!node.isPrivate,
+    external: node.external ? { ...node.external } : null,
+    inSuper: !!node.inSuper,
+    prototypeOnly: !!node.prototypeOnly,
+    ownerEnv: env
+  };
 }
 
 const procedureStatement = {


### PR DESCRIPTION
## Summary
- expand the PROCEDURE parser to recognise PRIVATE, EXTERNAL, and IN SUPER headers and support prototype declarations
- capture DEFINE PARAMETER statements separately from executable statements when building procedure bodies
- enforce runtime checks for private, external, super, and prototype procedures and register new header metadata keywords

## Testing
- node - <<'NODE'
const { interpret4GL } = require('./mini4GL');
(async () => {
  const program = `
    PROCEDURE Foo PRIVATE:
      DISPLAY "Hello".
    END PROCEDURE.

    RUN Foo.
  `;
  const result = await interpret4GL(program, { inputs: [] });
  console.log(result.output.join('\n'));
})();
NODE


------
https://chatgpt.com/codex/tasks/task_e_68ded08e0a108321bcfb6aba466050f0