### PR TITLE
Add INTEGER built-in conversion

### DIFF
--- a/mini4GL.js
+++ b/mini4GL.js
@@ -24,7 +24,7 @@
   - FIND ... : fetches a single Prisma record (supports FIRST, WHERE, OF, NO-ERROR).
   - Expressions: + - * /, parentheses, comparisons (=, <>, <, <=, >, >=), logical AND/OR/NOT
   - Strings with double quotes, numbers (int/float).
-  - Builtins: UPPER(s), LOWER(s), LENGTH(s), INT(n), FLOAT(n), PRINT(...) alias of DISPLAY
+  - Builtins: UPPER(s), LOWER(s), LENGTH(s), INT(n), INTEGER(n), FLOAT(n), PRINT(...) alias of DISPLAY
 
   Not implemented (you can extend): database buffers, TRANSACTION, temp-tables, advanced locking hints, triggers, frames.
 
@@ -487,6 +487,86 @@
     return isNaN(parsed.getTime()) ? null : parsed;
   }
 
+  const INT32_MIN=-2147483648;
+  const INT32_MAX=2147483647;
+  const JULIAN_DAY_BASE_MS=Date.UTC(-4712,0,1);
+
+  function roundHalfAwayFromZero(value){
+    if(!Number.isFinite(value)) return value;
+    if(value===0) return 0;
+    return value>0
+      ? Math.floor(value+0.5)
+      : Math.ceil(value-0.5);
+  }
+
+  function clampToInt32(value){
+    if(!Number.isFinite(value)){
+      throw new Error('INTEGER() argument is not a finite number');
+    }
+    const truncated=Math.trunc(value);
+    if(truncated<INT32_MIN || truncated>INT32_MAX){
+      throw new Error('INTEGER() result is out of range for 32-bit INTEGER');
+    }
+    return truncated;
+  }
+
+  const numericPattern=/^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$/;
+
+  function toIntegerValue(value){
+    if(value==null) return null;
+
+    if(typeof value==='number'){
+      if(!Number.isFinite(value)){
+        throw new Error('INTEGER() argument is not a finite number');
+      }
+      const rounded=roundHalfAwayFromZero(value);
+      return clampToInt32(rounded);
+    }
+
+    if(typeof value==='boolean'){
+      return value ? 1 : 0;
+    }
+
+    if(typeof value==='string'){
+      const trimmed=value.trim();
+      if(!numericPattern.test(trimmed)){
+        throw new Error(`INTEGER() cannot convert "${value}" to a number`);
+      }
+      const numericValue=Number(trimmed);
+      if(!Number.isFinite(numericValue)){
+        throw new Error('INTEGER() argument is not a finite number');
+      }
+      const rounded=roundHalfAwayFromZero(numericValue);
+      return clampToInt32(rounded);
+    }
+
+    if(typeof value==='bigint'){
+      const numericValue=Number(value);
+      if(!Number.isFinite(numericValue)){
+        throw new Error('INTEGER() argument is out of range');
+      }
+      const rounded=roundHalfAwayFromZero(numericValue);
+      return clampToInt32(rounded);
+    }
+
+    if(value instanceof Date){
+      if(isNaN(value.getTime())) return null;
+      const utcMs=Date.UTC(value.getUTCFullYear(), value.getUTCMonth(), value.getUTCDate());
+      const days=Math.floor((utcMs-JULIAN_DAY_BASE_MS)/86400000);
+      return clampToInt32(days);
+    }
+
+    if(value && typeof value.valueOf==='function' && value.valueOf()!==value){
+      return toIntegerValue(value.valueOf());
+    }
+
+    if(value && typeof value.__mini4glObjectId==='number'){
+      return clampToInt32(roundHalfAwayFromZero(value.__mini4glObjectId));
+    }
+
+    throw new Error('INTEGER() does not support this value type');
+  }
+
   function isDateFormatSpec(spec){
     if(typeof spec!=='string') return false;
     const trimmed=spec.trim();
@@ -931,6 +1011,7 @@
           case 'LOWER': return String(args[0]??'').toLowerCase();
           case 'LENGTH': return String(args[0]??'').length;
           case 'INT': return parseInt(args[0]??0,10);
+          case 'INTEGER': return toIntegerValue(args[0]);
           case 'FLOAT': return parseFloat(args[0]??0);
           case 'MONTH':{
             const date=parse4GLDate(args[0]);


### PR DESCRIPTION
## Summary
- mention the new INTEGER() built-in in the interpreter overview comment
- implement ABL-compatible INTEGER() conversion logic with rounding, validation, and 32-bit bounds
- wire the INTEGER() built-in into the expression evaluator alongside existing helpers

## Testing
- node - <<'NODE'
const { interpret4GL } = require('./mini4GL.js');
(async () => {
  const res = await interpret4GL('DISPLAY INTEGER(1.6). DISPLAY INTEGER(-1.6). DISPLAY INTEGER(" 42 "). DISPLAY INTEGER(1 = 1).', {});
  console.log(res.output);
})();
NODE

------
https://chatgpt.com/codex/tasks/task_e_68ded5f7ad448321b002fbe66ca428cc