### PR TITLE
Fix widget helper module loading for browser runtime

### DIFF
--- a/index.html
+++ b/index.html
@@ -187,6 +187,7 @@
       </div>
     </section>
 
+    <script src="./src/mini4gl/statements/widgetHelpers.js"></script>
     <script src="./src/mini4gl/statements/assign.js"></script>
     <script src="./src/mini4gl/statements/define.js"></script>
     <script src="./src/mini4gl/statements/procedure.js"></script>

--- a/src/mini4gl/statements/apply.js
+++ b/src/mini4gl/statements/apply.js
@@ -1,20 +1,33 @@
 'use strict';
 
-const widgetStateModule = typeof require === 'function'
-  ? require('./widgetState')
-  : (typeof globalThis !== 'undefined'
-      ? globalThis.Mini4GLWidgetState
+const applyWidgetHelpers = (() => {
+  if (typeof require === 'function') {
+    try {
+      return require('./widgetHelpers');
+    } catch (error) {
+      // Ignore and fall back to globals.
+    }
+  }
+  const scope =
+    typeof globalThis !== 'undefined'
+      ? globalThis
       : typeof window !== 'undefined'
-        ? window.Mini4GLWidgetState
+        ? window
         : typeof global !== 'undefined'
-          ? global.Mini4GLWidgetState
-          : null);
+          ? global
+          : {};
+  return {
+    getWidgetStateModule: () => scope.Mini4GLWidgetState || null
+  };
+})();
 
-if (!widgetStateModule) {
-  throw new Error('Widget state helpers are not available');
+function getWidgetStateModule() {
+  const module = applyWidgetHelpers.getWidgetStateModule();
+  if (!module) {
+    throw new Error('Widget state helpers are not available');
+  }
+  return module;
 }
-
-const widgetState = widgetStateModule;
 
 function isKeywordToken(tok, keyword) {
   if (!tok) {
@@ -51,6 +64,7 @@ function parseApply(parser) {
 }
 
 async function executeApplyEvent(node, env, context) {
+  const widgetState = getWidgetStateModule();
   const eventValue = widgetState.resolveEventName(node.eventExpr, env, context);
   const trimmed = eventValue.trim();
   if (!trimmed) {

--- a/src/mini4gl/statements/enable.js
+++ b/src/mini4gl/statements/enable.js
@@ -1,20 +1,33 @@
 'use strict';
 
-const widgetStateModule = typeof require === 'function'
-  ? require('./widgetState')
-  : (typeof globalThis !== 'undefined'
-      ? globalThis.Mini4GLWidgetState
+const enableWidgetHelpers = (() => {
+  if (typeof require === 'function') {
+    try {
+      return require('./widgetHelpers');
+    } catch (error) {
+      // Ignore and fall back to globals.
+    }
+  }
+  const scope =
+    typeof globalThis !== 'undefined'
+      ? globalThis
       : typeof window !== 'undefined'
-        ? window.Mini4GLWidgetState
+        ? window
         : typeof global !== 'undefined'
-          ? global.Mini4GLWidgetState
-          : null);
+          ? global
+          : {};
+  return {
+    getWidgetStateModule: () => scope.Mini4GLWidgetState || null
+  };
+})();
 
-if (!widgetStateModule) {
-  throw new Error('Widget state helpers are not available');
+function getWidgetStateModule() {
+  const module = enableWidgetHelpers.getWidgetStateModule();
+  if (!module) {
+    throw new Error('Widget state helpers are not available');
+  }
+  return module;
 }
-
-const widgetState = widgetStateModule;
 
 function parseEnable(parser) {
   parser.eat('ENABLE');
@@ -44,6 +57,7 @@ function parseEnable(parser) {
 }
 
 function executeEnableWidgets(node, env) {
+  const widgetState = getWidgetStateModule();
   for (const name of node.targets) {
     widgetState.setWidgetState(env, name, { enabled: true, visible: true });
   }

--- a/src/mini4gl/statements/on.js
+++ b/src/mini4gl/statements/on.js
@@ -1,20 +1,33 @@
 'use strict';
 
-const widgetStateModule = typeof require === 'function'
-  ? require('./widgetState')
-  : (typeof globalThis !== 'undefined'
-      ? globalThis.Mini4GLWidgetState
+const onWidgetHelpers = (() => {
+  if (typeof require === 'function') {
+    try {
+      return require('./widgetHelpers');
+    } catch (error) {
+      // Ignore and fall back to globals.
+    }
+  }
+  const scope =
+    typeof globalThis !== 'undefined'
+      ? globalThis
       : typeof window !== 'undefined'
-        ? window.Mini4GLWidgetState
+        ? window
         : typeof global !== 'undefined'
-          ? global.Mini4GLWidgetState
-          : null);
+          ? global
+          : {};
+  return {
+    getWidgetStateModule: () => scope.Mini4GLWidgetState || null
+  };
+})();
 
-if (!widgetStateModule) {
-  throw new Error('Widget state helpers are not available');
+function getWidgetStateModule() {
+  const module = onWidgetHelpers.getWidgetStateModule();
+  if (!module) {
+    throw new Error('Widget state helpers are not available');
+  }
+  return module;
 }
-
-const widgetState = widgetStateModule;
 
 function isKeywordToken(tok, keyword) {
   if (!tok) {
@@ -56,6 +69,7 @@ function parseOn(parser) {
 }
 
 function executeOnEvent(node, env, context) {
+  const widgetState = getWidgetStateModule();
   const eventValue = widgetState.resolveEventName(node.eventExpr, env, context);
   const trimmed = eventValue.trim();
   if (!trimmed) {

--- a/src/mini4gl/statements/view.js
+++ b/src/mini4gl/statements/view.js
@@ -1,20 +1,33 @@
 'use strict';
 
-const widgetStateModule = typeof require === 'function'
-  ? require('./widgetState')
-  : (typeof globalThis !== 'undefined'
-      ? globalThis.Mini4GLWidgetState
+const viewWidgetHelpers = (() => {
+  if (typeof require === 'function') {
+    try {
+      return require('./widgetHelpers');
+    } catch (error) {
+      // Ignore and fall back to globals.
+    }
+  }
+  const scope =
+    typeof globalThis !== 'undefined'
+      ? globalThis
       : typeof window !== 'undefined'
-        ? window.Mini4GLWidgetState
+        ? window
         : typeof global !== 'undefined'
-          ? global.Mini4GLWidgetState
-          : null);
+          ? global
+          : {};
+  return {
+    getWidgetStateModule: () => scope.Mini4GLWidgetState || null
+  };
+})();
 
-if (!widgetStateModule) {
-  throw new Error('Widget state helpers are not available');
+function getWidgetStateModule() {
+  const module = viewWidgetHelpers.getWidgetStateModule();
+  if (!module) {
+    throw new Error('Widget state helpers are not available');
+  }
+  return module;
 }
-
-const widgetState = widgetStateModule;
 
 function parseView(parser) {
   parser.eat('VIEW');
@@ -44,6 +57,7 @@ function parseView(parser) {
 }
 
 function executeViewWidgets(node, env) {
+  const widgetState = getWidgetStateModule();
   for (const name of node.targets) {
     widgetState.setWidgetState(env, name, { visible: true });
   }

--- a/src/mini4gl/statements/widgetHelpers.js
+++ b/src/mini4gl/statements/widgetHelpers.js
@@ -1,0 +1,76 @@
+'use strict';
+
+let cachedTypesModule = null;
+let cachedStateModule = null;
+
+function resolveGlobalScope() {
+  if (typeof globalThis !== 'undefined') {
+    return globalThis;
+  }
+  if (typeof window !== 'undefined') {
+    return window;
+  }
+  if (typeof global !== 'undefined') {
+    return global;
+  }
+  return {};
+}
+
+function tryRequire(path) {
+  if (typeof require !== 'function') {
+    return null;
+  }
+  try {
+    return require(path);
+  } catch (error) {
+    return null;
+  }
+}
+
+function getWidgetTypesModule() {
+  if (!cachedTypesModule) {
+    cachedTypesModule = tryRequire('./widgetTypes');
+    if (!cachedTypesModule) {
+      const scope = resolveGlobalScope();
+      cachedTypesModule = scope.Mini4GLWidgetTypes || null;
+    }
+    if (!cachedTypesModule) {
+      throw new Error('Widget helper modules are not available');
+    }
+  }
+  return cachedTypesModule;
+}
+
+function getWidgetStateModule() {
+  if (!cachedStateModule) {
+    cachedStateModule = tryRequire('./widgetState');
+    if (!cachedStateModule) {
+      const scope = resolveGlobalScope();
+      cachedStateModule = scope.Mini4GLWidgetState || null;
+    }
+    if (!cachedStateModule) {
+      throw new Error('Widget helper modules are not available');
+    }
+  }
+  return cachedStateModule;
+}
+
+function ensureWidgetHelpers() {
+  return {
+    widgetTypes: getWidgetTypesModule(),
+    widgetState: getWidgetStateModule()
+  };
+}
+
+const exported = {
+  getWidgetTypesModule,
+  getWidgetStateModule,
+  ensureWidgetHelpers
+};
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = exported;
+} else {
+  const scope = resolveGlobalScope();
+  scope.Mini4GLWidgetHelpers = exported;
+}


### PR DESCRIPTION
## Summary
- add a shared widgetHelpers module to resolve widgetTypes/widgetState in both Node and browser contexts
- update widget-related statements to lazily access the helpers so duplicate global declarations are avoided
- load the helper script in index.html to ensure the browser runtime can locate the shared helpers

## Testing
- node -e "require('./src/mini4gl/statements/widgetHelpers'); require('./src/mini4gl/statements/widgetState'); require('./src/mini4gl/statements/widgetTypes'); require('./src/mini4gl/statements/define'); require('./src/mini4gl/statements/createWidget'); require('./src/mini4gl/statements/enable'); require('./src/mini4gl/statements/view'); require('./src/mini4gl/statements/apply'); require('./src/mini4gl/statements/on'); require('./src/mini4gl/statements/waitFor'); console.log('ok');"

------
https://chatgpt.com/codex/tasks/task_e_68dfeb7ef5208321a9b529bbd6e105af