### PR TITLE
Wrap widget helper modules in IIFEs

### DIFF
--- a/src/mini4gl/statements/widgetState.js
+++ b/src/mini4gl/statements/widgetState.js
@@ -1,169 +1,172 @@
-'use strict';
+(function () {
+  'use strict';
 
-function getRootEnv(env) {
-  let current = env;
-  while (current && current.parent) {
-    current = current.parent;
-  }
-  return current || env;
-}
-
-function normalizeWidgetName(name) {
-  return String(name || '').trim().toLowerCase();
-}
-
-function ensureWidgetRegistry(env) {
-  const root = getRootEnv(env);
-  if (!root.widgets) {
-    root.widgets = Object.create(null);
-  }
-  return root.widgets;
-}
-
-function ensureWidgetEntry(env, name) {
-  const registry = ensureWidgetRegistry(env);
-  const key = normalizeWidgetName(name);
-  if (!registry[key]) {
-    registry[key] = {
-      name: key,
-      displayName: name,
-      type: null,
-      defined: false,
-      created: false,
-      enabled: false,
-      visible: false,
-      attributes: Object.create(null),
-      container: null,
-      lastEvent: null,
-      noUndo: false
-    };
-  }
-  return registry[key];
-}
-
-function defineWidget(env, widgetType, name, options = {}) {
-  const entry = ensureWidgetEntry(env, name);
-  entry.type = widgetType;
-  entry.displayName = name;
-  entry.defined = true;
-  entry.noUndo = !!options.noUndo;
-  if (!entry.attributes) {
-    entry.attributes = Object.create(null);
-  }
-  if (options.attributes) {
-    for (const [key, value] of Object.entries(options.attributes)) {
-      entry.attributes[key] = value;
+  function getRootEnv(env) {
+    let current = env;
+    while (current && current.parent) {
+      current = current.parent;
     }
+    return current || env;
   }
-  return entry;
-}
 
-function createWidget(env, widgetType, name, options = {}) {
-  const entry = ensureWidgetEntry(env, name);
-  if (widgetType) {
+  function normalizeWidgetName(name) {
+    return String(name || '').trim().toLowerCase();
+  }
+
+  function ensureWidgetRegistry(env) {
+    const root = getRootEnv(env);
+    if (!root.widgets) {
+      root.widgets = Object.create(null);
+    }
+    return root.widgets;
+  }
+
+  function ensureWidgetEntry(env, name) {
+    const registry = ensureWidgetRegistry(env);
+    const key = normalizeWidgetName(name);
+    if (!registry[key]) {
+      registry[key] = {
+        name: key,
+        displayName: name,
+        type: null,
+        defined: false,
+        created: false,
+        enabled: false,
+        visible: false,
+        attributes: Object.create(null),
+        container: null,
+        lastEvent: null,
+        noUndo: false
+      };
+    }
+    return registry[key];
+  }
+
+  function defineWidget(env, widgetType, name, options = {}) {
+    const entry = ensureWidgetEntry(env, name);
     entry.type = widgetType;
+    entry.displayName = name;
+    entry.defined = true;
+    entry.noUndo = !!options.noUndo;
+    if (!entry.attributes) {
+      entry.attributes = Object.create(null);
+    }
+    if (options.attributes) {
+      for (const [key, value] of Object.entries(options.attributes)) {
+        entry.attributes[key] = value;
+      }
+    }
+    return entry;
   }
-  entry.created = true;
-  entry.displayName = name;
-  if (options.container) {
-    entry.container = { ...options.container };
-  }
-  if (typeof options.visible === 'boolean') {
-    entry.visible = options.visible;
-  }
-  if (typeof options.enabled === 'boolean') {
-    entry.enabled = options.enabled;
-  }
-  return entry;
-}
 
-function setWidgetState(env, name, updates = {}) {
-  const entry = ensureWidgetEntry(env, name);
-  for (const [key, value] of Object.entries(updates)) {
-    entry[key] = value;
+  function createWidget(env, widgetType, name, options = {}) {
+    const entry = ensureWidgetEntry(env, name);
+    if (widgetType) {
+      entry.type = widgetType;
+    }
+    entry.created = true;
+    entry.displayName = name;
+    if (options.container) {
+      entry.container = { ...options.container };
+    }
+    if (typeof options.visible === 'boolean') {
+      entry.visible = options.visible;
+    }
+    if (typeof options.enabled === 'boolean') {
+      entry.enabled = options.enabled;
+    }
+    return entry;
   }
-  return entry;
-}
 
-function ensureEventRegistry(env) {
-  const root = getRootEnv(env);
-  if (!root.eventHandlers) {
-    root.eventHandlers = Object.create(null);
+  function setWidgetState(env, name, updates = {}) {
+    const entry = ensureWidgetEntry(env, name);
+    for (const [key, value] of Object.entries(updates)) {
+      entry[key] = value;
+    }
+    return entry;
   }
-  return root.eventHandlers;
-}
 
-function registerEventHandler(env, widgetName, eventName, handler) {
-  const registry = ensureEventRegistry(env);
-  const widgetKey = normalizeWidgetName(widgetName);
-  if (!registry[widgetKey]) {
-    registry[widgetKey] = Object.create(null);
+  function ensureEventRegistry(env) {
+    const root = getRootEnv(env);
+    if (!root.eventHandlers) {
+      root.eventHandlers = Object.create(null);
+    }
+    return root.eventHandlers;
   }
-  registry[widgetKey][eventName.toUpperCase()] = handler;
-}
 
-function getEventHandler(env, widgetName, eventName) {
-  const registry = ensureEventRegistry(env);
-  const widgetKey = normalizeWidgetName(widgetName);
-  const widgetHandlers = registry[widgetKey];
-  if (!widgetHandlers) {
-    return null;
+  function registerEventHandler(env, widgetName, eventName, handler) {
+    const registry = ensureEventRegistry(env);
+    const widgetKey = normalizeWidgetName(widgetName);
+    if (!registry[widgetKey]) {
+      registry[widgetKey] = Object.create(null);
+    }
+    registry[widgetKey][eventName.toUpperCase()] = handler;
   }
-  return widgetHandlers[eventName.toUpperCase()] || null;
-}
 
-async function triggerEvent(env, widgetName, eventName, context) {
-  const handler = getEventHandler(env, widgetName, eventName);
-  if (!handler) {
-    return false;
+  function getEventHandler(env, widgetName, eventName) {
+    const registry = ensureEventRegistry(env);
+    const widgetKey = normalizeWidgetName(widgetName);
+    const widgetHandlers = registry[widgetKey];
+    if (!widgetHandlers) {
+      return null;
+    }
+    return widgetHandlers[eventName.toUpperCase()] || null;
   }
-  const execEnv = handler.ownerEnv && typeof handler.ownerEnv === 'object'
-    ? handler.ownerEnv
-    : env;
-  if (handler.body) {
-    await context.execBlock(handler.body, execEnv);
-  }
-  setWidgetState(env, widgetName, { lastEvent: eventName.toUpperCase() });
-  return true;
-}
 
-function resolveEventName(eventExpr, env, context) {
-  if (!context || typeof context.evalExpr !== 'function') {
-    return '';
+  async function triggerEvent(env, widgetName, eventName, context) {
+    const handler = getEventHandler(env, widgetName, eventName);
+    if (!handler) {
+      return false;
+    }
+    const execEnv = handler.ownerEnv && typeof handler.ownerEnv === 'object'
+      ? handler.ownerEnv
+      : env;
+    if (handler.body) {
+      await context.execBlock(handler.body, execEnv);
+    }
+    setWidgetState(env, widgetName, { lastEvent: eventName.toUpperCase() });
+    return true;
   }
-  let raw = context.evalExpr(eventExpr, env);
-  if ((raw == null || String(raw).trim() === '') && eventExpr && eventExpr.type === 'Var') {
-    raw = eventExpr.name;
-  }
-  if (raw == null) {
-    return '';
-  }
-  return String(raw);
-}
-const exported = {
-  getRootEnv,
-  normalizeWidgetName,
-  ensureWidgetRegistry,
-  ensureWidgetEntry,
-  defineWidget,
-  createWidget,
-  setWidgetState,
-  registerEventHandler,
-  getEventHandler,
-  triggerEvent,
-  resolveEventName
-};
 
-if (typeof module !== 'undefined' && module.exports) {
-  module.exports = exported;
-} else {
-  const globalScope =
-    typeof globalThis !== 'undefined'
-      ? globalThis
-      : typeof window !== 'undefined'
-        ? window
-        : typeof global !== 'undefined'
-          ? global
-          : {};
-  globalScope.Mini4GLWidgetState = exported;
-}
+  function resolveEventName(eventExpr, env, context) {
+    if (!context || typeof context.evalExpr !== 'function') {
+      return '';
+    }
+    let raw = context.evalExpr(eventExpr, env);
+    if ((raw == null || String(raw).trim() === '') && eventExpr && eventExpr.type === 'Var') {
+      raw = eventExpr.name;
+    }
+    if (raw == null) {
+      return '';
+    }
+    return String(raw);
+  }
+
+  const exported = {
+    getRootEnv,
+    normalizeWidgetName,
+    ensureWidgetRegistry,
+    ensureWidgetEntry,
+    defineWidget,
+    createWidget,
+    setWidgetState,
+    registerEventHandler,
+    getEventHandler,
+    triggerEvent,
+    resolveEventName
+  };
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = exported;
+  } else {
+    const globalScope =
+      typeof globalThis !== 'undefined'
+        ? globalThis
+        : typeof window !== 'undefined'
+          ? window
+          : typeof global !== 'undefined'
+            ? global
+            : {};
+    globalScope.Mini4GLWidgetState = exported;
+  }
+}());

--- a/src/mini4gl/statements/widgetTypes.js
+++ b/src/mini4gl/statements/widgetTypes.js
@@ -1,122 +1,125 @@
-'use strict';
+(function () {
+  'use strict';
 
-const RAW_PATTERNS = [
-  { name: 'SELECTION-LIST', tokens: ['SELECTION', '-', 'LIST'] },
-  { name: 'SHADOW-WINDOW', tokens: ['SHADOW', '-', 'WINDOW'] },
-  { name: 'SUB-MENU', tokens: ['SUB', '-', 'MENU'] },
-  { name: 'MENU-ITEM', tokens: ['MENU', '-', 'ITEM'] },
-  { name: 'CONTROL-FRAME', tokens: ['CONTROL', '-', 'FRAME'] },
-  { name: 'DIALOG-BOX', tokens: ['DIALOG', '-', 'BOX'] },
-  { name: 'FIELD-GROUP', tokens: ['FIELD', '-', 'GROUP'] },
-  { name: 'COMBO-BOX', tokens: ['COMBO', '-', 'BOX'] },
-  { name: 'TOGGLE-BOX', tokens: ['TOGGLE', '-', 'BOX'] },
-  { name: 'RADIO-SET', tokens: ['RADIO', '-', 'SET'] },
-  { name: 'FILL-IN', tokens: ['FILL', '-', 'IN'] },
-  { name: 'WINDOW', tokens: ['WINDOW'] },
-  { name: 'TEXT', tokens: ['TEXT'] },
-  { name: 'SLIDER', tokens: ['SLIDER'] },
-  { name: 'RECTANGLE', tokens: ['RECTANGLE'] },
-  { name: 'MENU', tokens: ['MENU'] },
-  { name: 'LITERAL', tokens: ['LITERAL'] },
-  { name: 'IMAGE', tokens: ['IMAGE'] },
-  { name: 'FRAME', tokens: ['FRAME'] },
-  { name: 'EDITOR', tokens: ['EDITOR'] },
-  { name: 'BUTTON', tokens: ['BUTTON'] },
-  { name: 'BROWSE', tokens: ['BROWSE'] }
-];
+  const RAW_PATTERNS = [
+    { name: 'SELECTION-LIST', tokens: ['SELECTION', '-', 'LIST'] },
+    { name: 'SHADOW-WINDOW', tokens: ['SHADOW', '-', 'WINDOW'] },
+    { name: 'SUB-MENU', tokens: ['SUB', '-', 'MENU'] },
+    { name: 'MENU-ITEM', tokens: ['MENU', '-', 'ITEM'] },
+    { name: 'CONTROL-FRAME', tokens: ['CONTROL', '-', 'FRAME'] },
+    { name: 'DIALOG-BOX', tokens: ['DIALOG', '-', 'BOX'] },
+    { name: 'FIELD-GROUP', tokens: ['FIELD', '-', 'GROUP'] },
+    { name: 'COMBO-BOX', tokens: ['COMBO', '-', 'BOX'] },
+    { name: 'TOGGLE-BOX', tokens: ['TOGGLE', '-', 'BOX'] },
+    { name: 'RADIO-SET', tokens: ['RADIO', '-', 'SET'] },
+    { name: 'FILL-IN', tokens: ['FILL', '-', 'IN'] },
+    { name: 'WINDOW', tokens: ['WINDOW'] },
+    { name: 'TEXT', tokens: ['TEXT'] },
+    { name: 'SLIDER', tokens: ['SLIDER'] },
+    { name: 'RECTANGLE', tokens: ['RECTANGLE'] },
+    { name: 'MENU', tokens: ['MENU'] },
+    { name: 'LITERAL', tokens: ['LITERAL'] },
+    { name: 'IMAGE', tokens: ['IMAGE'] },
+    { name: 'FRAME', tokens: ['FRAME'] },
+    { name: 'EDITOR', tokens: ['EDITOR'] },
+    { name: 'BUTTON', tokens: ['BUTTON'] },
+    { name: 'BROWSE', tokens: ['BROWSE'] }
+  ];
 
-const UNIQUE_PATTERNS = [];
-const seen = new Set();
-for (const pattern of RAW_PATTERNS) {
-  if (seen.has(pattern.name)) {
-    continue;
-  }
-  seen.add(pattern.name);
-  UNIQUE_PATTERNS.push(pattern);
-}
-
-UNIQUE_PATTERNS.sort((a, b) => b.tokens.length - a.tokens.length);
-
-function peekAhead(parser, offset) {
-  return parser.toks[parser.i + offset];
-}
-
-function tokenMatchesPart(token, part) {
-  if (!token) {
-    return false;
-  }
-  if (part === '-') {
-    return token.type === 'OP' && token.value === '-';
-  }
-  const upper = token.type === 'IDENT' ? token.value.toUpperCase() : token.type;
-  return upper === part;
-}
-
-function consumePart(parser, part) {
-  if (part === '-') {
-    const tok = parser.eat('OP');
-    if (tok.value !== '-') {
-      throw new SyntaxError('Expected hyphen in widget type');
+  const UNIQUE_PATTERNS = [];
+  const seen = new Set();
+  for (const pattern of RAW_PATTERNS) {
+    if (seen.has(pattern.name)) {
+      continue;
     }
-    return;
+    seen.add(pattern.name);
+    UNIQUE_PATTERNS.push(pattern);
   }
-  const next = parser.peek();
-  if (!next) {
-    throw new SyntaxError(`Unexpected end while reading widget type ${part}`);
-  }
-  if (next.type === 'IDENT') {
-    const consumed = parser.eat('IDENT');
-    if (consumed.value.toUpperCase() !== part) {
-      throw new SyntaxError(`Expected ${part} in widget type`);
-    }
-    return;
-  }
-  if (next.type === part) {
-    parser.eat(part);
-    return;
-  }
-  throw new SyntaxError(`Unexpected token ${next.type} when reading widget type`);
-}
 
-function matchesPattern(parser, pattern) {
-  for (let index = 0; index < pattern.tokens.length; index += 1) {
-    const part = pattern.tokens[index];
-    const token = peekAhead(parser, index);
-    if (!tokenMatchesPart(token, part)) {
+  UNIQUE_PATTERNS.sort((a, b) => b.tokens.length - a.tokens.length);
+
+  function peekAhead(parser, offset) {
+    return parser.toks[parser.i + offset];
+  }
+
+  function tokenMatchesPart(token, part) {
+    if (!token) {
       return false;
     }
-  }
-  return true;
-}
-
-function readWidgetType(parser) {
-  for (const pattern of UNIQUE_PATTERNS) {
-    if (matchesPattern(parser, pattern)) {
-      for (const part of pattern.tokens) {
-        consumePart(parser, part);
-      }
-      return pattern.name;
+    if (part === '-') {
+      return token.type === 'OP' && token.value === '-';
     }
+    const upper = token.type === 'IDENT' ? token.value.toUpperCase() : token.type;
+    return upper === part;
   }
-  const next = parser.peek();
-  const near = next ? String(next.value || next.type) : 'EOF';
-  throw new SyntaxError(`Unknown widget type near ${near}`);
-}
-const exported = {
-  SUPPORTED_WIDGET_TYPES: UNIQUE_PATTERNS.map((p) => p.name),
-  readWidgetType
-};
 
-if (typeof module !== 'undefined' && module.exports) {
-  module.exports = exported;
-} else {
-  const globalScope =
-    typeof globalThis !== 'undefined'
-      ? globalThis
-      : typeof window !== 'undefined'
-        ? window
-        : typeof global !== 'undefined'
-          ? global
-          : {};
-  globalScope.Mini4GLWidgetTypes = exported;
-}
+  function consumePart(parser, part) {
+    if (part === '-') {
+      const tok = parser.eat('OP');
+      if (tok.value !== '-') {
+        throw new SyntaxError('Expected hyphen in widget type');
+      }
+      return;
+    }
+    const next = parser.peek();
+    if (!next) {
+      throw new SyntaxError(`Unexpected end while reading widget type ${part}`);
+    }
+    if (next.type === 'IDENT') {
+      const consumed = parser.eat('IDENT');
+      if (consumed.value.toUpperCase() !== part) {
+        throw new SyntaxError(`Expected ${part} in widget type`);
+      }
+      return;
+    }
+    if (next.type === part) {
+      parser.eat(part);
+      return;
+    }
+    throw new SyntaxError(`Unexpected token ${next.type} when reading widget type`);
+  }
+
+  function matchesPattern(parser, pattern) {
+    for (let index = 0; index < pattern.tokens.length; index += 1) {
+      const part = pattern.tokens[index];
+      const token = peekAhead(parser, index);
+      if (!tokenMatchesPart(token, part)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  function readWidgetType(parser) {
+    for (const pattern of UNIQUE_PATTERNS) {
+      if (matchesPattern(parser, pattern)) {
+        for (const part of pattern.tokens) {
+          consumePart(parser, part);
+        }
+        return pattern.name;
+      }
+    }
+    const next = parser.peek();
+    const near = next ? String(next.value || next.type) : 'EOF';
+    throw new SyntaxError(`Unknown widget type near ${near}`);
+  }
+
+  const exported = {
+    SUPPORTED_WIDGET_TYPES: UNIQUE_PATTERNS.map((p) => p.name),
+    readWidgetType
+  };
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = exported;
+  } else {
+    const globalScope =
+      typeof globalThis !== 'undefined'
+        ? globalThis
+        : typeof window !== 'undefined'
+          ? window
+          : typeof global !== 'undefined'
+            ? global
+            : {};
+    globalScope.Mini4GLWidgetTypes = exported;
+  }
+}());


### PR DESCRIPTION
## Summary
- wrap the widget types and widget state helper scripts in immediately-invoked functions
- keep exporting the same API while avoiding duplicate global constant declarations when the scripts load multiple times

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfef2456208321b747be0eeadcdc28