### PR TITLE
Allow optional equals in ASSIGN statements

### DIFF
--- a/src/mini4gl/statements/assign.js
+++ b/src/mini4gl/statements/assign.js
@@ -3,9 +3,11 @@
 function parseAssign(parser) {
   parser.match('ASSIGN');
   const id = parser.eat('IDENT').value;
-  const assignTok = parser.eat('OP');
-  if (assignTok.value !== '=') {
-    throw new SyntaxError(`Expected '=' but got ${assignTok.value}`);
+  const assignTok = parser.match('OP');
+  if (assignTok) {
+    if (assignTok.value !== '=') {
+      throw new SyntaxError(`Expected '=' but got ${assignTok.value}`);
+    }
   }
   const value = parser.parseExpr();
   parser.optionalDot();


### PR DESCRIPTION
## Summary
- allow the ASSIGN statement parser to treat the equals sign as optional
- keep validation for unexpected operators when present

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dff0fc73808321902e36b816c667a5