### PR TITLE
Handle DISPLAY WITH FRAME parsing

### DIFF
--- a/src/mini4gl/statements/display.js
+++ b/src/mini4gl/statements/display.js
@@ -46,6 +46,13 @@ function parseDisplay(parser) {
       if (next.type === 'CENTERED') {
         parser.eat('CENTERED');
         withOptions.push('CENTERED');
+      } else if (next.type === 'FRAME') {
+        parser.eat('FRAME');
+        const frameTarget = parser.peek();
+        if (isExprStartToken(frameTarget)) {
+          parser.parseExpr();
+        }
+        withOptions.push('FRAME');
       } else if (next.type === 'IDENT') {
         withOptions.push(parser.eat('IDENT').value.toUpperCase());
       } else {


### PR DESCRIPTION
## Summary
- allow the DISPLAY statement parser to consume WITH FRAME clauses so trailing identifiers no longer cause syntax errors

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dff594da40832192a808c3cf624e72