### PR TITLE
Recognize FRAME keyword in parser

### DIFF
--- a/src/mini4gl/parser.js
+++ b/src/mini4gl/parser.js
@@ -35,6 +35,7 @@
     'LABEL',
     'FORMAT',
     'WITH',
+    'FRAME',
     'CENTERED',
     'PROCEDURE',
     'RUN',


### PR DESCRIPTION
## Summary
- treat FRAME as a reserved keyword so WITH FRAME clauses consume their arguments correctly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e01abf7bd48321a56bb6fe6681341a