### PR TITLE
Fix button widget display output

### DIFF
--- a/mini4GL.js
+++ b/mini4GL.js
@@ -410,7 +410,30 @@
     toIntegerValue
   });
 
+  function describeWidgetValue(widget){
+    if(!widget || typeof widget !== 'object') return '';
+    const attrs = widget.attributes || {};
+    const label = attrs.LABEL ?? attrs.TEXT ?? attrs.TITLE ?? attrs.HELP;
+    if(label != null && String(label).trim() !== ''){
+      return String(label);
+    }
+    const baseName = widget.displayName || widget.name || '';
+    const type = widget.type ? String(widget.type).toUpperCase() : 'WIDGET';
+    if(baseName){
+      return `[${type} ${baseName}]`;
+    }
+    return `[${type}]`;
+  }
+
   function formatDisplayValue(value, formatSpec){
+    if(value && typeof value === 'object' && value.__mini4glWidget){
+      const widgetText = describeWidgetValue(value);
+      const rawWidget = widgetText == null ? '' : String(widgetText);
+      if(formatSpec == null){
+        return rawWidget;
+      }
+      return formatDisplayValue(rawWidget, formatSpec);
+    }
     const raw=value==null ? '' : String(value);
     if(formatSpec==null) return raw;
     const spec=String(formatSpec);

--- a/src/mini4gl/statements/define.js
+++ b/src/mini4gl/statements/define.js
@@ -215,10 +215,19 @@ function executeDefineWidget(node, env, context) {
   for (const attribute of node.attributes) {
     computedAttributes[attribute.name] = context.evalExpr(attribute.expr, env);
   }
-  widgetState.defineWidget(env, node.widgetType, node.name, {
+  const entry = widgetState.defineWidget(env, node.widgetType, node.name, {
     attributes: computedAttributes,
     noUndo: node.noUndo
   });
+  const varName = node.name.toLowerCase();
+  env.vars[varName] = entry;
+  if (env.varDefs) {
+    env.varDefs[varName] = {
+      dataType: node.widgetType,
+      isWidget: true,
+      noUndo: node.noUndo
+    };
+  }
 }
 
 const defineStatement = {

--- a/src/mini4gl/statements/widgetState.js
+++ b/src/mini4gl/statements/widgetState.js
@@ -26,6 +26,7 @@
     const key = normalizeWidgetName(name);
     if (!registry[key]) {
       registry[key] = {
+        __mini4glWidget: true,
         name: key,
         displayName: name,
         type: null,


### PR DESCRIPTION
## Summary
- mark stored widget registry entries so they can be recognized when formatting DISPLAY output
- bind DEFINEd widgets into the variable table to expose their attributes during execution
- render widget labels (or fallback descriptions) when a widget value is displayed

## Testing
- node - <<'NODE'
const { interpret4GL } = require('./mini4GL');
(async () => {
  const program = `DEFINE BUTTON btnOk LABEL "OK".
DEFINE BUTTON btnCancel LABEL "Annuler" AUTO-END-KEY.
DISPLAY btnOk btnCancel WITH FRAME frDemo.`;
  const result = await interpret4GL(program, {});
  console.log(result.output);
})();
NODE


------
https://chatgpt.com/codex/tasks/task_e_68e01d09e5ac8321a8063187ab8d22f4