### PR TITLE
Render widget buttons in the playground output

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,7 +101,7 @@
         font-family: inherit;
         min-width: 220px;
       }
-      pre {
+      .output-surface {
         background: rgba(0, 0, 0, 0.55);
         border-radius: 8px;
         padding: 1rem;
@@ -109,6 +109,50 @@
         min-height: 200px;
         overflow: auto;
         font-size: 0.95rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        white-space: pre-wrap;
+      }
+      .output-line {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 0.5rem;
+        white-space: pre-wrap;
+      }
+      .output-line.centered {
+        justify-content: center;
+      }
+      .output-line-text {
+        white-space: pre-wrap;
+      }
+      .widget-button {
+        border: 1px solid rgba(255, 255, 255, 0.25);
+        border-radius: 6px;
+        padding: 0.4rem 1.1rem;
+        background: rgba(255, 255, 255, 0.12);
+        color: inherit;
+        font-family: inherit;
+        font-size: 0.9rem;
+        font-weight: 500;
+        cursor: pointer;
+        transition: background 0.2s ease, transform 0.15s ease;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 0.35rem;
+      }
+      .widget-button:hover:not(:disabled) {
+        background: rgba(255, 255, 255, 0.2);
+        transform: translateY(-1px);
+      }
+      .widget-button:disabled {
+        opacity: 0.6;
+        cursor: not-allowed;
+      }
+      .widget-button.is-hidden {
+        opacity: 0.35;
       }
       .status {
         font-size: 0.9rem;
@@ -167,7 +211,7 @@
       <section class="panel">
         <div>
           <h2>Sortie</h2>
-          <pre id="output"></pre>
+          <div id="output" class="output-surface"></div>
         </div>
         <div>
           <h2>Statut</h2>
@@ -467,11 +511,84 @@ WAIT-FOR CLOSE OF FRAME frDialog.`
       }
 
       function clearOutput() {
-        outputEl.textContent = '';
+        outputEl.innerHTML = '';
+      }
+
+      function createTextSpan(text) {
+        const span = document.createElement('span');
+        span.className = 'output-line-text';
+        span.textContent = text;
+        return span;
+      }
+
+      function renderWidgetSegment(segment) {
+        const widgetType = String(segment.widgetType || '').toUpperCase();
+        if (widgetType === 'BUTTON') {
+          const button = document.createElement('button');
+          button.type = 'button';
+          button.className = 'widget-button';
+          const label =
+            (segment.attributes && segment.attributes.LABEL) ||
+            segment.label ||
+            segment.widgetName ||
+            'Bouton';
+          button.textContent = String(label);
+          button.disabled = segment.enabled === false;
+          if (segment.visible === false) {
+            button.classList.add('is-hidden');
+          }
+          return button;
+        }
+        const fallback = document.createElement('span');
+        fallback.className = 'output-line-text';
+        const text = segment.label || segment.widgetName || '[Widget]';
+        fallback.textContent = String(text);
+        return fallback;
       }
 
       function appendOutput(line) {
-        outputEl.textContent += line + '\n';
+        const lineEl = document.createElement('div');
+        lineEl.className = 'output-line';
+        let handled = false;
+
+        if (line && typeof line === 'object' && line.kind === 'rich') {
+          if (line.centered) {
+            lineEl.classList.add('centered');
+          }
+          const segments = Array.isArray(line.segments) ? line.segments : [];
+          segments.forEach((segment) => {
+            if (!segment) {
+              return;
+            }
+            if (segment.kind === 'widget') {
+              const element = renderWidgetSegment(segment);
+              if (element) {
+                lineEl.appendChild(element);
+                handled = true;
+              }
+              return;
+            }
+            if (segment.kind === 'text') {
+              lineEl.appendChild(
+                createTextSpan(segment.text != null ? String(segment.text) : '')
+              );
+              handled = true;
+              return;
+            }
+            lineEl.appendChild(createTextSpan(String(segment)));
+            handled = true;
+          });
+        } else {
+          lineEl.appendChild(createTextSpan(line == null ? '' : String(line)));
+          handled = true;
+        }
+
+        if (!handled) {
+          lineEl.appendChild(createTextSpan(''));
+        }
+
+        outputEl.appendChild(lineEl);
+        outputEl.scrollTop = outputEl.scrollHeight;
       }
 
       function setStatus(message, isError = false) {
@@ -483,7 +600,11 @@ WAIT-FOR CLOSE OF FRAME frDialog.`
         const collected = [];
         const result = await Mini4GL.interpret4GL(source, {
           onOutput: (line) => {
-            collected.push(String(line));
+            if (line && typeof line === 'object') {
+              collected.push(line);
+            } else {
+              collected.push(String(line));
+            }
           }
         });
         return collected.length ? collected : result.output || [];

--- a/src/mini4gl/statements/display.js
+++ b/src/mini4gl/statements/display.js
@@ -67,27 +67,133 @@ function parseDisplay(parser) {
   return { type: 'Display', items, withOptions };
 }
 
+function isWidgetValue(value) {
+  return value && typeof value === 'object' && value.__mini4glWidget;
+}
+
+function cloneWidgetAttributes(widget) {
+  const attributes = Object.create(null);
+  const source = widget && widget.attributes;
+  if (!source || typeof source !== 'object') {
+    return attributes;
+  }
+  for (const [key, val] of Object.entries(source)) {
+    if (typeof val === 'function') {
+      continue;
+    }
+    try {
+      attributes[key] = val;
+    } catch (_) {
+      // Ignore attributes that cannot be copied as-is.
+    }
+  }
+  return attributes;
+}
+
+function buildWidgetSegment(widget, context) {
+  const upperType = widget && widget.type ? String(widget.type).toUpperCase() : null;
+  const isCreated = !!(widget && widget.created);
+  const hasEnabledFlag = !!(widget && Object.prototype.hasOwnProperty.call(widget, 'enabled'));
+  const hasVisibleFlag = !!(widget && Object.prototype.hasOwnProperty.call(widget, 'visible'));
+  const segment = {
+    kind: 'widget',
+    widgetType: upperType,
+    widgetName: widget && (widget.displayName || widget.name) ? String(widget.displayName || widget.name) : null,
+    attributes: cloneWidgetAttributes(widget),
+    enabled: isCreated
+      ? widget && widget.enabled !== false
+      : hasEnabledFlag && widget && widget.enabled === true
+        ? true
+        : true,
+    visible: isCreated
+      ? widget && widget.visible !== false
+      : hasVisibleFlag && widget && widget.visible === true
+        ? true
+        : true,
+    label: ''
+  };
+  if (context && typeof context.describeWidgetValue === 'function') {
+    try {
+      segment.label = context.describeWidgetValue(widget);
+    } catch (_) {
+      segment.label = '';
+    }
+  }
+  if (!segment.label && segment.attributes && segment.attributes.LABEL != null) {
+    segment.label = String(segment.attributes.LABEL);
+  }
+  if (!segment.label && segment.widgetName) {
+    segment.label = segment.widgetName;
+  }
+  return segment;
+}
+
+function mergeAdjacentTextSegments(segments) {
+  const merged = [];
+  for (const segment of segments) {
+    if (!segment) {
+      continue;
+    }
+    if (segment.kind === 'text') {
+      const text = segment.text != null ? String(segment.text) : '';
+      if (!merged.length || merged[merged.length - 1].kind !== 'text') {
+        merged.push({ kind: 'text', text });
+      } else {
+        merged[merged.length - 1].text += text;
+      }
+      continue;
+    }
+    merged.push(segment);
+  }
+  return merged;
+}
+
 function executeDisplay(node, env, context) {
-  const parts = node.items.map((item) => {
+  const hasCenteredOption =
+    Array.isArray(node.withOptions) &&
+    node.withOptions.some((opt) => String(opt).toUpperCase() === 'CENTERED');
+
+  const segments = [];
+  let containsWidget = false;
+
+  node.items.forEach((item, index) => {
+    if (index > 0) {
+      segments.push({ kind: 'text', text: ' ' });
+    }
     const value = context.evalExpr(item.expr, env);
+    const labelValue = item.label ? context.evalExpr(item.label, env) : null;
+    const labelText = labelValue == null ? '' : String(labelValue);
+
+    if (isWidgetValue(value)) {
+      containsWidget = true;
+      if (labelText) {
+        segments.push({ kind: 'text', text: `${labelText} ` });
+      }
+      segments.push(buildWidgetSegment(value, context));
+      return;
+    }
+
     const formatted = context.formatDisplayValue(
       value,
       item.format ? context.evalExpr(item.format, env) : null
     );
-    if (item.label) {
-      const labelVal = context.evalExpr(item.label, env);
-      const labelStr = labelVal == null ? '' : String(labelVal);
-      if (labelStr.length) {
-        return `${labelStr} ${formatted}`.trim();
-      }
-    }
-    return formatted;
+    const text = labelText ? `${labelText} ${formatted}`.trim() : formatted;
+    segments.push({ kind: 'text', text });
   });
-  let line = parts.join(' ');
-  if (node.withOptions && node.withOptions.some((opt) => String(opt).toUpperCase() === 'CENTERED')) {
-    line = context.centerLine(line);
+
+  if (!containsWidget) {
+    const combined = segments.map((segment) => String(segment.text || '')).join('');
+    const finalLine = hasCenteredOption ? context.centerLine(combined) : combined;
+    env.output(finalLine);
+    return;
   }
-  env.output(line);
+
+  const mergedSegments = mergeAdjacentTextSegments(segments);
+  env.output({
+    kind: 'rich',
+    centered: !!hasCenteredOption,
+    segments: mergedSegments
+  });
 }
 
 const displayStatement = {


### PR DESCRIPTION
## Summary
- add rich output metadata for DISPLAY so button widgets are preserved instead of string labels
- expose widget descriptions in the runtime and update the browser overlay sink to render button elements
- refresh the playground UI output area to render structured lines with styled HTML buttons

## Testing
- `node - <<'NODE'
const { interpret4GL } = require('./mini4GL.js');
(async () => {
  const program = `DEFINE BUTTON btnOk LABEL "OK".
DEFINE BUTTON btnCancel LABEL "Annuler" AUTO-END-KEY.
DISPLAY btnOk btnCancel WITH FRAME frDemo.`;
  const result = await interpret4GL(program, {});
  console.log(JSON.stringify(result.output, null, 2));
})();
NODE`
- `node - <<'NODE'
const { interpret4GL } = require('./mini4GL.js');
(async () => {
  const program = `DISPLAY "Hello".`;
  const result = await interpret4GL(program, {});
  console.log(result.output);
})();
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68e1338383f8832194eb43db3786c725